### PR TITLE
Add targeting-related WcApi hooks

### DIFF
--- a/Data/Scripts/CoreSystems/Ai/AiDatabase.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiDatabase.cs
@@ -40,7 +40,10 @@ namespace CoreSystems.Support
 
         internal void Scan()
         {
-            MyGamePruningStructure.GetAllTopMostEntitiesInSphere(ref ScanVolume, _possibleTargets);
+            if (Session.I.ScanTargetsAction == null)
+                MyGamePruningStructure.GetAllTopMostEntitiesInSphere(ref ScanVolume, _possibleTargets);
+            else
+                Session.I.ScanTargetsAction.Invoke(GridEntity, ScanVolume, _possibleTargets);
             NearByEntitiesTmp = _possibleTargets.Count;
 
             for (int i = 0; i < NearByEntitiesTmp; i++)

--- a/Data/Scripts/CoreSystems/Ai/AiTargeting.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiTargeting.cs
@@ -246,9 +246,15 @@ namespace CoreSystems.Support
                 Vector3D targetAccel = accelPrediction ? info.Target.Physics?.LinearAcceleration ?? Vector3D.Zero : Vector3.Zero;
                 Vector3D predictedPos;
 
+                // WcApi turret target validation
+                if (Session.I.ValidateWeaponTargetFunc != null &&
+                    !Session.I.ValidateWeaponTargetFunc.Invoke(w.Comp.TerminalBlock, w.PartId, info.Target))
+                    continue;
+
                 if (info.IsGrid)
                 {
                     if (!s.TrackGrids || !overRides.Grids || (!overRides.LargeGrid && info.LargeGrid) || (!overRides.SmallGrid && !info.LargeGrid) || !focusTarget && info.FatCount < 2) continue;
+
                     if (w.System.TargetGridCenter)
                     {
                         if (!Weapon.CanShootTarget(w, ref targetCenter, targetLinVel, targetAccel, out predictedPos, false, null, MathFuncs.DebugCaller.CanShootTarget2)) continue;

--- a/Data/Scripts/CoreSystems/Api/ApiBackend.cs
+++ b/Data/Scripts/CoreSystems/Api/ApiBackend.cs
@@ -141,6 +141,8 @@ namespace CoreSystems.Api
                 ["IsInRange"] = new Func<IMyEntity, MyTuple<bool, bool>>(IsInRangeLegacy),
                 ["GetConstructEffectiveDpsBase"] = new Func<MyEntity, float>(GetConstructEffectiveDps),
                 ["GetConstructEffectiveDps"] = new Func<IMyEntity, float>(GetConstructEffectiveDpsLegacy),
+                ["AddScanTargetsAction"] = new Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>>(AddScanTargetsAction),
+                ["RemoveScanTargetsAction"] = new Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>>(RemoveScanTargetsAction),
 
                 // Phantoms
                 ["GetTargetAssessment"] = new Func<MyEntity, MyEntity, int, bool, bool, MyTuple<bool, bool, Vector3D?>>(GetPhantomTargetAssessment),
@@ -1519,6 +1521,18 @@ namespace CoreSystems.Api
             }
             return new MyTuple<bool, bool>();
         }
+
+        private void AddScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action)
+        {
+            Session.I.ScanTargetsAction += action;
+        }
+
+        private void RemoveScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action)
+        {
+            Session.I.ScanTargetsAction -= action;
+        }
+
+
         ///
         /// Phantoms
         /// 

--- a/Data/Scripts/CoreSystems/Api/ApiBackend.cs
+++ b/Data/Scripts/CoreSystems/Api/ApiBackend.cs
@@ -143,6 +143,7 @@ namespace CoreSystems.Api
                 ["GetConstructEffectiveDps"] = new Func<IMyEntity, float>(GetConstructEffectiveDpsLegacy),
                 ["AddScanTargetsAction"] = new Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>>(AddScanTargetsAction),
                 ["RemoveScanTargetsAction"] = new Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>>(RemoveScanTargetsAction),
+                ["SetValidateWeaponTargetFunc"] = new Action<Func<Sandbox.ModAPI.IMyTerminalBlock, int, MyEntity, bool>>(SetValidateWeaponTargetFunc),
 
                 // Phantoms
                 ["GetTargetAssessment"] = new Func<MyEntity, MyEntity, int, bool, bool, MyTuple<bool, bool, Vector3D?>>(GetPhantomTargetAssessment),
@@ -1530,6 +1531,11 @@ namespace CoreSystems.Api
         private void RemoveScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action)
         {
             Session.I.ScanTargetsAction -= action;
+        }
+
+        private void SetValidateWeaponTargetFunc(Func<Sandbox.ModAPI.IMyTerminalBlock, int, MyEntity, bool> func)
+        {
+            Session.I.ValidateWeaponTargetFunc = func;
         }
 
 

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Sandbox.Game.Entities;
 using Sandbox.ModAPI;
 using VRage;
 using VRage.Collections;
@@ -91,6 +92,8 @@ namespace CoreSystems.Api
         private Func<MyEntity, int, MyTuple<MyDefinitionId, string, string, bool>> _getMagazineMap;
         private Func<MyEntity, int, MyDefinitionId, bool, bool> _setMagazine;
         private Func<MyEntity, int, bool> _forceReload;
+        private Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>> _addScanTargetsAction;
+        private Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>> _removeScanTargetsAction;
 
         public void SetWeaponTarget(MyEntity weapon, MyEntity target, int weaponId = 0) =>
             _setWeaponTarget?.Invoke(weapon, target, weaponId);
@@ -467,6 +470,18 @@ namespace CoreSystems.Api
 
         }
 
+        /// <summary>
+        /// Registers an action that tells a given grid's AI available target entities in a given sphere.
+        /// </summary>
+        /// <param name="action"></param>
+        public void AddScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action) => _addScanTargetsAction?.Invoke(action);
+
+        /// <summary>
+        /// Unregisters an action that tells a given grid's AI available target entities in a given sphere.
+        /// </summary>
+        /// <param name="action"></param>
+        public void RemoveScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action) => _removeScanTargetsAction?.Invoke(action);
+
         private const long Channel = 67549756549;
         private bool _getWeaponDefinitions;
         private bool _isRegistered;
@@ -616,6 +631,9 @@ namespace CoreSystems.Api
 
             AssignMethod(delegates, "SetMagazine", ref _setMagazine);
             AssignMethod(delegates, "ForceReload", ref _forceReload);
+
+            AssignMethod(delegates, "AddScanTargetsAction", ref _addScanTargetsAction);
+            AssignMethod(delegates, "RemoveScanTargetsAction", ref _removeScanTargetsAction);
 
             // Damage handler
             AssignMethod(delegates, "DamageHandler", ref _registerDamageEvent);

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
@@ -94,6 +94,7 @@ namespace CoreSystems.Api
         private Func<MyEntity, int, bool> _forceReload;
         private Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>> _addScanTargetsAction;
         private Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>> _removeScanTargetsAction;
+        private Action<Func<IMyTerminalBlock, int, MyEntity, bool>> _setValidateWeaponTargetFunc;
 
         public void SetWeaponTarget(MyEntity weapon, MyEntity target, int weaponId = 0) =>
             _setWeaponTarget?.Invoke(weapon, target, weaponId);
@@ -482,6 +483,13 @@ namespace CoreSystems.Api
         /// <param name="action"></param>
         public void RemoveScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action) => _removeScanTargetsAction?.Invoke(action);
 
+        /// <summary>
+        /// Assigns a function that determines if a given weapon can target a given entity.
+        /// </summary>
+        /// <param name="func">Block, PartId, target</param>
+        public void SetValidateWeaponTargetFunc(Func<IMyTerminalBlock, int, MyEntity, bool> func) =>
+            _setValidateWeaponTargetFunc?.Invoke(func);
+
         private const long Channel = 67549756549;
         private bool _getWeaponDefinitions;
         private bool _isRegistered;
@@ -634,6 +642,7 @@ namespace CoreSystems.Api
 
             AssignMethod(delegates, "AddScanTargetsAction", ref _addScanTargetsAction);
             AssignMethod(delegates, "RemoveScanTargetsAction", ref _removeScanTargetsAction);
+            AssignMethod(delegates, "SetValidateWeaponTargetFunc", ref _setValidateWeaponTargetFunc);
 
             // Damage handler
             AssignMethod(delegates, "DamageHandler", ref _registerDamageEvent);

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
@@ -472,19 +472,19 @@ namespace CoreSystems.Api
         }
 
         /// <summary>
-        /// Registers an action that tells a given grid's AI available target entities in a given sphere.
+        /// Registers an action that tells a given grid's AI available target entities in a given sphere. NOT NETWORKED - make sure this is synced in your mod.
         /// </summary>
         /// <param name="action"></param>
         public void AddScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action) => _addScanTargetsAction?.Invoke(action);
 
         /// <summary>
-        /// Unregisters an action that tells a given grid's AI available target entities in a given sphere.
+        /// Unregisters an action that tells a given grid's AI available target entities in a given sphere. NOT NETWORKED - make sure this is synced in your mod.
         /// </summary>
         /// <param name="action"></param>
         public void RemoveScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action) => _removeScanTargetsAction?.Invoke(action);
 
         /// <summary>
-        /// Assigns a function that determines if a given weapon can target a given entity.
+        /// Assigns a function that determines if a given weapon can target a given entity. NOT NETWORKED - make sure this is synced in your mod.
         /// </summary>
         /// <param name="func">Block, PartId, target</param>
         public void SetValidateWeaponTargetFunc(Func<IMyTerminalBlock, int, MyEntity, bool> func) =>

--- a/Data/Scripts/CoreSystems/Session/SessionFields.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionFields.cs
@@ -332,6 +332,7 @@ namespace CoreSystems
         internal Projectiles.Projectiles Projectiles;
         internal ApiBackend Api;
         internal Action<Vector3, float> ProjectileAddedCallback = (location, health) => { };
+        internal Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> ScanTargetsAction = null;
         internal ShieldApi SApi = new ShieldApi();
         internal NetworkReporter Reporter = new NetworkReporter();
         internal MyStorageData TmpStorage = new MyStorageData();

--- a/Data/Scripts/CoreSystems/Session/SessionFields.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionFields.cs
@@ -332,7 +332,14 @@ namespace CoreSystems
         internal Projectiles.Projectiles Projectiles;
         internal ApiBackend Api;
         internal Action<Vector3, float> ProjectileAddedCallback = (location, health) => { };
+        /// <summary>
+        /// WcApi action for feeding targets to grid AI. Overrides default if not null.
+        /// </summary>
         internal Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> ScanTargetsAction = null;
+        /// <summary>
+        /// WcApi function for checking if a weapon's target is allowed. Defaults true if null.
+        /// </summary>
+        internal Func<IMyTerminalBlock, int, MyEntity, bool> ValidateWeaponTargetFunc = null;
         internal ShieldApi SApi = new ShieldApi();
         internal NetworkReporter Reporter = new NetworkReporter();
         internal MyStorageData TmpStorage = new MyStorageData();


### PR DESCRIPTION
Add/Remove ScanTargetsAction - allows control of available targets for grid AI
SetValidateWeaponTargetFunc - allows inline weapon target control

Both are non-networked and apply at the session level.