### PR TITLE
Allow modders to do a WC Vanilla replacer without putting it in the mod name

### DIFF
--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -1121,6 +1121,8 @@ namespace CoreSystems
                     ReplaceVanilla = true;
                 else if (mod.GetPath().Contains("AppData\\Roaming\\SpaceEngineers\\Mods\\VanillaReplacement") || mod.Name.Contains("WCVanilla") || mod.FriendlyName != null && mod.FriendlyName.Contains("WCVanilla"))
                     ReplaceVanilla = true;
+                else if (MyAPIGateway.Utilities.FileExistsInModLocation("Data\\WCVanilla.txt", mod))
+                    ReplaceVanilla = true;
                 else if (mod.PublishedFileId == 2189703321 || mod.PublishedFileId == 2496225055 || mod.PublishedFileId == 2726343161 || mod.PublishedFileId == 2734980390)
                     DebugVersion = true;
                 else if (mod.PublishedFileId == 2200451495 || mod.PublishedFileId == 3283226082)


### PR DESCRIPTION
Allows modders another option to tell WC there are vanilla replacement weapons by adding a file named `WCVanilla.txt` in a mod's `Data` folder, file can be empty.

(I don't want to have to put that string into the user viewable name)