### PR TITLE
Various Additions

### DIFF
--- a/Data/Scripts/CoreSystems/Api/ApiBackend.cs
+++ b/Data/Scripts/CoreSystems/Api/ApiBackend.cs
@@ -1322,7 +1322,13 @@ namespace CoreSystems.Api
 
         private float GetMaxPower(MyDefinitionId weaponDef)
         {
-            return 0f; //Need to implement
+            CoreStructure structure;
+            if (Session.I.PartPlatforms.TryGetValue(weaponDef, out structure))
+            {
+                return structure.ActualPeakPowerCombined;
+            }
+
+            return 0f;
         }
 
         private static void ModOverrideLegacy(IMyEntity weaponBlock) => ModOverride((MyEntity) weaponBlock);

--- a/Data/Scripts/CoreSystems/Api/ApiBackend.cs
+++ b/Data/Scripts/CoreSystems/Api/ApiBackend.cs
@@ -1322,7 +1322,13 @@ namespace CoreSystems.Api
 
         private float GetMaxPower(MyDefinitionId weaponDef)
         {
-            return 0f; //Need to implement
+            CoreStructure structure;
+            if (Session.I.PartPlatforms.TryGetValue(weaponDef, out structure))
+            {
+                return structure.MaxPowerMW + structure.CombinedIdlePower;
+            }
+
+            return 0f;
         }
 
         private static void ModOverrideLegacy(IMyEntity weaponBlock) => ModOverride((MyEntity) weaponBlock);

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -519,6 +519,7 @@ namespace CoreSystems.Support
                 [ProtoMember(26)] internal float InventoryFillAmount;
                 [ProtoMember(27)] internal float InventoryLowAmount;
                 [ProtoMember(28)] internal bool UseWorldInventoryVolumeMultiplier;
+                [ProtoMember(29)] internal bool DisableOverheat;
             }
 
 

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -667,6 +667,7 @@ namespace CoreSystems.Support
             [ProtoMember(31)] internal bool NoGridOrArmorScaling;
             [ProtoMember(32)] internal string TerminalName;
             [ProtoMember(33)] internal float BaseDamageCutoff;
+            [ProtoMember(34)] internal bool IgnoreGrids;
 
 
             [ProtoContract]

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -521,6 +521,7 @@ namespace CoreSystems.Support
                 [ProtoMember(28)] internal bool UseWorldInventoryVolumeMultiplier;
                 [ProtoMember(29)] internal bool DisableOverheat;
                 [ProtoMember(30)] internal DegradeSettingsDef DegradeRofSettings;
+                [ProtoMember(31)] internal float HeatSinkRateOverheatMult;
 
                 [ProtoContract]
                 public struct DegradeSettingsDef

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -670,6 +670,7 @@ namespace CoreSystems.Support
             [ProtoMember(33)] internal float BaseDamageCutoff;
             [ProtoMember(34)] internal bool IgnoreGrids;
             [ProtoMember(35)] internal bool AllowNegativeHeatModifier;
+            [ProtoMember(36)] internal int HeatNeededToFire;
 
 
             [ProtoContract]

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -1284,6 +1284,7 @@ namespace CoreSystems.Support
                 [ProtoMember(8)] internal string ShieldHitSound;
                 [ProtoMember(9)] internal string ShotSound;
                 [ProtoMember(10)] internal string WaterHitSound;
+                [ProtoMember(11)] internal bool OverrideShotSound;
             }
 
             [ProtoContract]

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -519,7 +519,7 @@ namespace CoreSystems.Support
                 [ProtoMember(26)] internal float InventoryFillAmount;
                 [ProtoMember(27)] internal float InventoryLowAmount;
                 [ProtoMember(28)] internal bool UseWorldInventoryVolumeMultiplier;
-                [ProtoMember(29)] internal bool DisableOverheat;
+                [ProtoMember(29)] internal bool AllowOverheatShooting;
                 [ProtoMember(30)] internal DegradeSettingsDef DegradeRofSettings;
                 [ProtoMember(31)] internal float HeatSinkRateOverheatMult;
 

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -520,6 +520,19 @@ namespace CoreSystems.Support
                 [ProtoMember(27)] internal float InventoryLowAmount;
                 [ProtoMember(28)] internal bool UseWorldInventoryVolumeMultiplier;
                 [ProtoMember(29)] internal bool DisableOverheat;
+                [ProtoMember(30)] internal DegradeSettingsDef DegradeRofSettings;
+
+                [ProtoContract]
+                public struct DegradeSettingsDef
+                {
+                    [ProtoMember(1)] internal float HeatThresholdStart;
+                    [ProtoMember(2)] internal float HeatThresholdEnd;
+                    [ProtoMember(3)] internal float RofAt0Heat;
+                    [ProtoMember(4)] internal float RofAt100Heat;
+
+                    // if DegradeRof is active (heat went above HeatThresholdStart and has not went below HeatThresholdEnd,
+                    // then lerp between RofAt0Heat and RofAt100Heat using heat percentage.
+                }
             }
 
 

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -668,6 +668,7 @@ namespace CoreSystems.Support
             [ProtoMember(32)] internal string TerminalName;
             [ProtoMember(33)] internal float BaseDamageCutoff;
             [ProtoMember(34)] internal bool IgnoreGrids;
+            [ProtoMember(35)] internal bool AllowNegativeHeatModifier;
 
 
             [ProtoContract]

--- a/Data/Scripts/CoreSystems/Definitions/CoreStructure.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreStructure.cs
@@ -24,6 +24,7 @@ namespace CoreSystems.Support
         internal EnittyTypes EntityType;
         internal float ApproximatePeakPowerCombined;
         internal float ActualPeakPowerCombined;
+        internal float MaxPowerMW; // not touching the above 2's calculations so new var
         internal float CombinedIdlePower;
         internal int PowerPriority;
         internal enum EnittyTypes
@@ -51,6 +52,7 @@ namespace CoreSystems.Support
         internal int DefaultLeadGroup = 0;
         internal WeaponStructure(Session session, KeyValuePair<string, Dictionary<string, MyTuple<string, string, string, string>>> tDef, List<WeaponDefinition> wDefList, string modPath)
         {
+            MaxPowerMW = 0;
             Session = session;
             SubtypeId = tDef.Key;
             var map = tDef.Value;
@@ -205,6 +207,7 @@ namespace CoreSystems.Support
                 if (coreSystem.Values.HardPoint.Ai.TurretAttached && !TurretAttached)
                     TurretAttached = true;
                 ApproximatePeakPowerCombined += coreSystem.ApproximatePeakPower;
+                MaxPowerMW += coreSystem.WeaponAmmoMaxPowerMW;
                 CombinedIdlePower += coreSystem.WConst.IdlePower;
 
                 PartSystems.Add(partNameIdHash, coreSystem);

--- a/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
@@ -750,6 +750,7 @@ namespace CoreSystems.Support
         internal bool HasServerOverrides;
         internal bool FireSoundNoBurst;
         internal bool HasDrone;
+        internal bool DisableOverheat;
 
         internal WeaponConstants(WeaponDefinition values)
         {
@@ -771,6 +772,7 @@ namespace CoreSystems.Support
             AimingToleranceRads = MathHelperD.ToRadians(values.HardPoint.AimingTolerance <= 0 ? 180 : values.HardPoint.AimingTolerance);
 
             HeatPerShot = values.HardPoint.Loading.HeatPerShot;
+            DisableOverheat = values.HardPoint.Loading.DisableOverheat;
             HeatSinkRate = values.HardPoint.Loading.HeatSinkRate;
 
             IdlePower = Math.Max(values.HardPoint.HardWare.IdlePower, 0.001f);

--- a/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
@@ -523,10 +523,10 @@ namespace CoreSystems.Support
                 rofAt0Heat = Values.HardPoint.Loading.DegradeRofSettings.RofAt0Heat;
                 rofAt100Heat = Values.HardPoint.Loading.DegradeRofSettings.RofAt100Heat;
 
-                if (heatThresholdStart < 0) heatThresholdStart = 0.8f;
-                if (heatThresholdEnd < 0) heatThresholdEnd = 0.4f;
-                if (rofAt0Heat < 0) rofAt0Heat = 1f;
-                if (rofAt100Heat < 0) rofAt100Heat = 0.25f;
+                if (heatThresholdStart < 0 || heatThresholdStart > 1f) heatThresholdStart = 0.8f;
+                if (heatThresholdEnd < 0 || heatThresholdEnd > 1f) heatThresholdEnd = 0.4f;
+                if (rofAt0Heat < 0) rofAt0Heat = 1f; // let this be >1 if user wants
+                if (rofAt100Heat < 0) rofAt100Heat = 0.25f; // let this be >1 if user wants
             }
             else
             {

--- a/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
@@ -806,7 +806,7 @@ namespace CoreSystems.Support
             AimingToleranceRads = MathHelperD.ToRadians(values.HardPoint.AimingTolerance <= 0 ? 180 : values.HardPoint.AimingTolerance);
 
             HeatPerShot = values.HardPoint.Loading.HeatPerShot;
-            DisableOverheat = values.HardPoint.Loading.DisableOverheat;
+            DisableOverheat = values.HardPoint.Loading.AllowOverheatShooting;
             HeatSinkRate = values.HardPoint.Loading.HeatSinkRate;
 
             IdlePower = Math.Max(values.HardPoint.HardWare.IdlePower, 0.001f);

--- a/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
@@ -252,6 +252,7 @@ namespace CoreSystems.Support
         public readonly float HeatThresholdEnd;
         public readonly float RofAt0Heat;
         public readonly float RofAt100Heat;
+        public readonly float HeatSinkRateOverheatMult;
 
         public bool AnimationsInited;
 
@@ -374,7 +375,7 @@ namespace CoreSystems.Support
             AltScopeName = HasScope ? "subpart_" + Values.Assignments.Scope : string.Empty;
             PainterUseMaxTargeting = Values.HardPoint.Ai.PainterUseMaxTargeting;
             TurretMovements(out AzStep, out ElStep, out MinAzimuth, out MaxAzimuth, out MinElevation, out MaxElevation, out HomeAzimuth, out HomeElevation, out TurretMovement);
-            Heat(out DegRof, out MaxHeat, out WepCoolDown, out ProhibitCoolingWhenOff, out HeatThresholdStart, out HeatThresholdEnd, out RofAt0Heat, out RofAt100Heat);
+            Heat(out DegRof, out MaxHeat, out WepCoolDown, out ProhibitCoolingWhenOff, out HeatThresholdStart, out HeatThresholdEnd, out RofAt0Heat, out RofAt100Heat, out HeatSinkRateOverheatMult);
             BarrelValues(out BarrelsPerShot, out ShotsPerBurst);
             BarrelsAv(out BarrelEffect1, out BarrelEffect2, out Barrel1AvTicks, out Barrel2AvTicks, out BarrelSpinRate, out HasBarrelRotation);
             Track(out ScanTrackOnly, out NonThreatsOnly, out TrackProjectile, out TrackGrids, out TrackCharacters, out TrackMeteors, out TrackNeutrals, out ScanNonThreats, out ScanThreats, out MaxTrackingTime, out MaxTrackingTicks, out TrackTopMostEntities);
@@ -507,12 +508,14 @@ namespace CoreSystems.Support
             projectilesOnly = projectilesFirst && Values.Targeting.Threats.Length == 1;
         }
 
-        private void Heat(out bool degRof, out int maxHeat, out float wepCoolDown, out bool coolWhenOff, out float heatThresholdStart, out float heatThresholdEnd, out float rofAt0Heat, out float rofAt100Heat)
+        private void Heat(out bool degRof, out int maxHeat, out float wepCoolDown, out bool coolWhenOff, out float heatThresholdStart, out float heatThresholdEnd, out float rofAt0Heat, out float rofAt100Heat, out float heatSinkRateOverheatMult)
         {
             coolWhenOff = Values.HardPoint.Loading.ProhibitCoolingWhenOff;
             degRof = Values.HardPoint.Loading.DegradeRof;
             maxHeat = Values.HardPoint.Loading.MaxHeat;
             wepCoolDown = Values.HardPoint.Loading.Cooldown;
+            heatSinkRateOverheatMult = Values.HardPoint.Loading.HeatSinkRateOverheatMult;
+
             if (wepCoolDown < 0) wepCoolDown = 0;
             if (wepCoolDown > .95f) wepCoolDown = .95f;
 
@@ -523,10 +526,10 @@ namespace CoreSystems.Support
                 rofAt0Heat = Values.HardPoint.Loading.DegradeRofSettings.RofAt0Heat;
                 rofAt100Heat = Values.HardPoint.Loading.DegradeRofSettings.RofAt100Heat;
 
-                if (heatThresholdStart < 0 || heatThresholdStart > 1f) heatThresholdStart = 0.8f;
-                if (heatThresholdEnd < 0 || heatThresholdEnd > 1f) heatThresholdEnd = 0.4f;
-                if (rofAt0Heat < 0) rofAt0Heat = 1f; // let this be >1 if user wants
-                if (rofAt100Heat < 0) rofAt100Heat = 0.25f; // let this be >1 if user wants
+                if (heatThresholdStart <= 0 || heatThresholdStart > 1f) heatThresholdStart = 0.8f;
+                if (heatThresholdEnd <= 0 || heatThresholdEnd > 1f) heatThresholdEnd = 0.4f;
+                if (rofAt0Heat <= 0) rofAt0Heat = 1f; // let this be >1 if user wants
+                if (rofAt100Heat <= 0) rofAt100Heat = 0.25f; // let this be >1 if user wants
             }
             else
             {

--- a/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
@@ -247,6 +247,7 @@ namespace CoreSystems.Support
         public readonly float NoAmmoSoundDistSqr;
         public readonly float HardPointAvMaxDistSqr;
         public readonly float ApproximatePeakPower;
+        public readonly float WeaponAmmoMaxPowerMW; // no idea what approx. peak power is used for so make a new variable
         public readonly float HeatThresholdStart;
         public readonly float HeatThresholdEnd;
         public readonly float RofAt0Heat;
@@ -387,6 +388,7 @@ namespace CoreSystems.Support
             // CheckForBadAnimations();
 
             ApproximatePeakPower = WConst.IdlePower;
+            WeaponAmmoMaxPowerMW = 0;
 
             var ammoSelections = 0;
             for (int i = 0; i < AmmoTypes.Length; i++) // remap old configs
@@ -431,6 +433,11 @@ namespace CoreSystems.Support
 
                 if (aConst.ChargSize > ApproximatePeakPower)
                     ApproximatePeakPower = ammo.AmmoDef.Const.ChargSize;
+
+                if (aConst.PowerPerTick > WeaponAmmoMaxPowerMW && ammo.AmmoDef.HardPointUsable && (aConst.EnergyAmmo || aConst.IsHybrid))
+                {
+                    WeaponAmmoMaxPowerMW = ammo.AmmoDef.Const.PowerPerTick;
+                }
 
                 if (aConst.RequiresTarget)
                     requiresTarget = true;

--- a/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreSystems.cs
@@ -247,6 +247,10 @@ namespace CoreSystems.Support
         public readonly float NoAmmoSoundDistSqr;
         public readonly float HardPointAvMaxDistSqr;
         public readonly float ApproximatePeakPower;
+        public readonly float HeatThresholdStart;
+        public readonly float HeatThresholdEnd;
+        public readonly float RofAt0Heat;
+        public readonly float RofAt100Heat;
 
         public bool AnimationsInited;
 
@@ -369,7 +373,7 @@ namespace CoreSystems.Support
             AltScopeName = HasScope ? "subpart_" + Values.Assignments.Scope : string.Empty;
             PainterUseMaxTargeting = Values.HardPoint.Ai.PainterUseMaxTargeting;
             TurretMovements(out AzStep, out ElStep, out MinAzimuth, out MaxAzimuth, out MinElevation, out MaxElevation, out HomeAzimuth, out HomeElevation, out TurretMovement);
-            Heat(out DegRof, out MaxHeat, out WepCoolDown, out ProhibitCoolingWhenOff);
+            Heat(out DegRof, out MaxHeat, out WepCoolDown, out ProhibitCoolingWhenOff, out HeatThresholdStart, out HeatThresholdEnd, out RofAt0Heat, out RofAt100Heat);
             BarrelValues(out BarrelsPerShot, out ShotsPerBurst);
             BarrelsAv(out BarrelEffect1, out BarrelEffect2, out Barrel1AvTicks, out Barrel2AvTicks, out BarrelSpinRate, out HasBarrelRotation);
             Track(out ScanTrackOnly, out NonThreatsOnly, out TrackProjectile, out TrackGrids, out TrackCharacters, out TrackMeteors, out TrackNeutrals, out ScanNonThreats, out ScanThreats, out MaxTrackingTime, out MaxTrackingTicks, out TrackTopMostEntities);
@@ -496,7 +500,7 @@ namespace CoreSystems.Support
             projectilesOnly = projectilesFirst && Values.Targeting.Threats.Length == 1;
         }
 
-        private void Heat(out bool degRof, out int maxHeat, out float wepCoolDown, out bool coolWhenOff)
+        private void Heat(out bool degRof, out int maxHeat, out float wepCoolDown, out bool coolWhenOff, out float heatThresholdStart, out float heatThresholdEnd, out float rofAt0Heat, out float rofAt100Heat)
         {
             coolWhenOff = Values.HardPoint.Loading.ProhibitCoolingWhenOff;
             degRof = Values.HardPoint.Loading.DegradeRof;
@@ -504,6 +508,26 @@ namespace CoreSystems.Support
             wepCoolDown = Values.HardPoint.Loading.Cooldown;
             if (wepCoolDown < 0) wepCoolDown = 0;
             if (wepCoolDown > .95f) wepCoolDown = .95f;
+
+            if (degRof)
+            {
+                heatThresholdStart = Values.HardPoint.Loading.DegradeRofSettings.HeatThresholdStart;
+                heatThresholdEnd = Values.HardPoint.Loading.DegradeRofSettings.HeatThresholdEnd;
+                rofAt0Heat = Values.HardPoint.Loading.DegradeRofSettings.RofAt0Heat;
+                rofAt100Heat = Values.HardPoint.Loading.DegradeRofSettings.RofAt100Heat;
+
+                if (heatThresholdStart < 0) heatThresholdStart = 0.8f;
+                if (heatThresholdEnd < 0) heatThresholdEnd = 0.4f;
+                if (rofAt0Heat < 0) rofAt0Heat = 1f;
+                if (rofAt100Heat < 0) rofAt100Heat = 0.25f;
+            }
+            else
+            {
+                heatThresholdStart = 0.8f;
+                heatThresholdEnd = 0.4f;
+                rofAt0Heat = 1f;
+                rofAt100Heat = 0.25f;
+            }
         }
 
         private void BarrelsAv(out bool barrelEffect1, out bool barrelEffect2, out float barrel1AvTicks, out float barrel2AvTicks, out int barrelSpinRate, out bool hasBarrelRotation)

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -497,7 +497,7 @@ namespace CoreSystems.Support
 
             var givenSpeed = AmmoModsFound && Overrides.DesiredSpeed.HasValue ? Math.Max(Overrides.DesiredSpeed.Value, 0f) : ammo.AmmoDef.Trajectory.DesiredSpeed;
             DesiredProjectileSpeed = !IsBeamWeapon ? givenSpeed : MaxTrajectory * MyEngineConstants.UPDATE_STEPS_PER_SECOND;
-            HeatModifier = ammo.AmmoDef.HeatModifier > 0 ? ammo.AmmoDef.HeatModifier : 1;
+            HeatModifier = ammo.AmmoDef.HeatModifier > 0 || ammo.AmmoDef.AllowNegativeHeatModifier ? ammo.AmmoDef.HeatModifier : 1;
             ShieldHeatScaler = MyUtils.IsZero(ammo.AmmoDef.DamageScales.Shields.HeatModifier) ? 1 : ammo.AmmoDef.DamageScales.Shields.HeatModifier;
 
             ComputeShieldBypass(shieldBypassRaw, out ShieldDamageBypassMod, out ShieldAntiPenMod);

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -1125,7 +1125,7 @@ namespace CoreSystems.Support
             var ammoDef = ammo.AmmoDef;
             var weaponShotSound = !string.IsNullOrEmpty(system.Values.HardPoint.Audio.FiringSound);
             var ammoShotSound = !string.IsNullOrEmpty(ammoDef.AmmoAudio.ShotSound);
-            var useWeaponShotSound = !ammo.IsShrapnel && weaponShotSound && !ammoShotSound;
+            var useWeaponShotSound = !ammo.IsShrapnel && weaponShotSound && !ammoShotSound && !ammoDef.AmmoAudio.OverrideShotSound;
 
 
             rawShotSoundStr = useWeaponShotSound ? system.Values.HardPoint.Audio.FiringSound : ammoDef.AmmoAudio.ShotSound;

--- a/Data/Scripts/CoreSystems/EntityComp/Controls/Weapon/WeaponActions.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Controls/Weapon/WeaponActions.cs
@@ -141,7 +141,11 @@ namespace CoreSystems.Control
                 return;
             
             var numValue = (int)comp.Data.Repo.Values.Set.Overrides.Control;
-            var value = numValue + 1 <= 2 ? numValue + 1 : 0;
+            int value;
+            if (Session.I.Settings.Enforcement.ProhibitHUDPainter)
+                value = numValue == 1 ? 0 : 1;
+            else
+                value = numValue + 1 <= 2 ? numValue + 1 : 0;
 
             Weapon.WeaponComponent.RequestSetValue(comp, "ControlModes", value, Session.I.PlayerId);
         }

--- a/Data/Scripts/CoreSystems/EntityComp/Controls/Weapon/WeaponUi.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Controls/Weapon/WeaponUi.cs
@@ -1144,7 +1144,12 @@ namespace CoreSystems
 
         internal static void ListControlModes(List<MyTerminalControlComboBoxItem> controlList)
         {
-            foreach (var sub in ControlList) controlList.Add(sub);
+            foreach (var sub in ControlList)
+            {
+                if (sub.Key != 2 || !Session.I.Settings.Enforcement.ProhibitHUDPainter)
+                    controlList.Add(sub);
+            }
+            
         }
 
         private static readonly List<MyTerminalControlComboBoxItem> ControlList = new List<MyTerminalControlComboBoxItem>

--- a/Data/Scripts/CoreSystems/EntityComp/EntityEvents.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/EntityEvents.cs
@@ -253,8 +253,7 @@ namespace CoreSystems.Support
                     stringBuilder.Append($"\n{Localization.GetText("WeaponInfoInsufficientPower")}");
             }
 
-           
-
+            bool needsHeat = false;
             for (int i = 0; i < collection.Count; i++)
             {
                 var w = collection[i];
@@ -265,6 +264,9 @@ namespace CoreSystems.Support
                     shots += $"\n{Localization.GetText("WeaponInfoDrawOverMax")}: {SinkPower - IdlePower:0.00}/ {w.ActiveAmmoDef.AmmoDef.Const.PowerPerTick:0.00} {Localization.GetText("WeaponInfoMWLabel")}" +
                     $"\n{(chargeTime == 0 ? Localization.GetText("WeaponInfoPowerCharged") : Localization.GetText("WeaponInfoPowerChargedIn") + " " + chargeTime + Localization.GetText("WeaponInfoSeconds"))}";
                 }
+
+                if (w.ActiveAmmoDef.AmmoDef.AllowNegativeHeatModifier)
+                    needsHeat = true;
 
                 var endReturn = i + 1 != collection.Count ? "\n" : string.Empty;
                 var timeToLoad = (int)(w.ReloadEndTick - Session.I.Tick) / 60;
@@ -289,7 +291,7 @@ namespace CoreSystems.Support
                 stringBuilder.Append(endReturn);
             }
                 
-            if (HeatPerSecond > 0)
+            if (HeatPerSecond > 0 || CurrentHeat > 0)
                 stringBuilder.Append($"\n{Localization.GetText("WeaponInfoHeatPerSecOverMax")}: {HeatPerSecond}/{MaxHeat}" +
                     $"\n{Localization.GetText("WeaponInfoCurrentHeat")}: {CurrentHeat:0.} W ({(CurrentHeat / MaxHeat):P})");
                 

--- a/Data/Scripts/CoreSystems/EntityComp/EntityEvents.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/EntityEvents.cs
@@ -303,7 +303,7 @@ namespace CoreSystems.Support
                 {
                     var w = collection[i];
                     var systemRate = w.ActiveAmmoDef.AmmoDef.Const.RealShotsPerMin * comp.Data.Repo.Values.Set.RofModifier;
-                    var heatModifier = MathHelper.Lerp(1f, .25f, w.PartState.Heat / w.System.MaxHeat);
+                    var heatModifier = MathHelper.Lerp(w.System.RofAt0Heat, w.System.RofAt100Heat, w.PartState.Heat / w.System.MaxHeat);
                     systemRate *= w.CurrentlyDegrading ? heatModifier : 1;
 
                     stringBuilder.Append($" {(collection.Count > 1 ? $"\n{w.FriendlyName}" : string.Empty)}" +

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponComp.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponComp.cs
@@ -580,6 +580,10 @@ namespace CoreSystems.Platform
                         break;
                     case "ControlModes":
                         o.Control = (ProtoWeaponOverrides.ControlModes)v;
+
+                        if (o.Control == ProtoWeaponOverrides.ControlModes.Painter && Session.I.Settings.Enforcement.ProhibitHUDPainter)
+                            o.Control = ProtoWeaponOverrides.ControlModes.Auto;
+
                         if (comp.TypeSpecific == CompTypeSpecific.Rifle)
                             Session.I.RequestNotify($"Targeting Mode [{o.Control}]", 3000, "White", playerId, true);
                         clearTargets = true;

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponController.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponController.cs
@@ -258,7 +258,8 @@ namespace CoreSystems.Platform
         {
             if (!System.ProhibitCoolingWhenOff || System.ProhibitCoolingWhenOff && Comp.Cube.IsWorking)
             {
-                var hsRateMod = HsRate + (float)Comp.HeatLoss;
+
+                var hsRateMod = HsRate * (PartState.Overheated && System.HeatSinkRateOverheatMult != 0 ? System.HeatSinkRateOverheatMult : 1f) + (float)Comp.HeatLoss;
                 Comp.CurrentHeat = Comp.CurrentHeat >= hsRateMod ? Comp.CurrentHeat - hsRateMod : 0;
                 PartState.Heat = PartState.Heat >= hsRateMod ? PartState.Heat - hsRateMod : 0;
                 Comp.HeatLoss = 0;
@@ -311,6 +312,7 @@ namespace CoreSystems.Platform
                 if (Session.I.IsServer)
                 {
                     PartState.Overheated = false;
+
                     OverHeatCountDown = 0;
                     if (Session.I.MpActive)
                         Session.I.SendState(Comp);

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponController.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponController.cs
@@ -4,6 +4,7 @@ using VRage.Utils;
 using VRageMath;
 using static CoreSystems.Support.WeaponDefinition.AnimationDef.PartAnimationSetDef;
 using static CoreSystems.Support.CoreComponent;
+using Sandbox.ModAPI;
 
 namespace CoreSystems.Platform
 {
@@ -291,14 +292,14 @@ namespace CoreSystems.Platform
                 LastHeat = PartState.Heat;
             }
 
-            if (set && System.DegRof && PartState.Heat >= (System.MaxHeat * .8))
+            if (set && System.DegRof && PartState.Heat >= (System.MaxHeat * System.HeatThresholdStart))
             {
                 CurrentlyDegrading = true;
                 UpdateRof();
             }
             else if (set && CurrentlyDegrading)
             {
-                if (PartState.Heat <= (System.MaxHeat * .4)) 
+                if (PartState.Heat <= (System.MaxHeat * System.HeatThresholdEnd)) 
                     CurrentlyDegrading = false;
 
                 UpdateRof();
@@ -330,7 +331,7 @@ namespace CoreSystems.Platform
         {
             var systemRate = System.WConst.RateOfFire * Comp.Data.Repo.Values.Set.RofModifier;
             var barrelRate = System.BarrelSpinRate * Comp.Data.Repo.Values.Set.RofModifier;
-            var heatModifier = MathHelper.Lerp(1f, .25f, PartState.Heat / System.MaxHeat);
+            var heatModifier = MathHelper.Lerp(System.RofAt0Heat, System.RofAt100Heat, PartState.Heat / System.MaxHeat);
 
             systemRate *= CurrentlyDegrading ? heatModifier : 1;
 

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponFields.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponFields.cs
@@ -234,9 +234,8 @@ namespace CoreSystems.Platform
             {
                 var reloading = ActiveAmmoDef.AmmoDef.Const.Reloadable && ClientMakeUpShots == 0 && (Loading || ProtoWeaponAmmo.CurrentAmmo == 0 || Reload.WaitForClient);
                 var overHeat = PartState.Overheated && OverHeatCountDown == 0;
-                var canShoot = !overHeat && !reloading ;
-                var shotReady = canShoot;
-                return shotReady;
+                var needsHeat = ActiveAmmoDef.AmmoDef.HeatNeededToFire > 0 ? PartState.Heat < ActiveAmmoDef.AmmoDef.HeatNeededToFire : false;
+                return !overHeat && !reloading && !needsHeat;
             }
         }
 

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponShoot.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponShoot.cs
@@ -270,9 +270,14 @@ namespace CoreSystems.Platform
 
                         PartState.Heat += HeatPShot;
                         Comp.CurrentHeat += HeatPShot;
-                        if (PartState.Heat >= System.MaxHeat || PartState.Overheated) {
+                        if ((PartState.Heat >= System.MaxHeat || PartState.Overheated) && !System.WConst.DisableOverheat)
+                        {
                             OverHeat();
                             break;
+                        }
+                        else if (System.WConst.DisableOverheat && PartState.Heat >= System.MaxHeat)
+                        {
+                            PartState.Heat = System.MaxHeat;
                         }
                     }
                     

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponShoot.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponShoot.cs
@@ -275,9 +275,13 @@ namespace CoreSystems.Platform
                             OverHeat();
                             break;
                         }
-                        else if (System.WConst.DisableOverheat && PartState.Heat >= System.MaxHeat)
+                        else if (System.WConst.DisableOverheat)
                         {
-                            PartState.Heat = System.MaxHeat;
+                            if (PartState.Heat >= System.MaxHeat)
+                                PartState.Heat = System.MaxHeat;
+
+                            if (Comp.CurrentHeat >= Comp.MaxHeat)
+                                Comp.CurrentHeat = Comp.MaxHeat;
                         }
                     }
                     

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponShoot.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponShoot.cs
@@ -261,7 +261,7 @@ namespace CoreSystems.Platform
 
                     _muzzlesToFire.Add(MuzzleIdToName[current]);
 
-                    if (HeatPShot > 0) {
+                    if (HeatPShot > 0 || ActiveAmmoDef.AmmoDef.AllowNegativeHeatModifier) {
 
                         if (!HeatLoopRunning) {
                             s.FutureEvents.Schedule(UpdateWeaponHeat, null, 20);

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponTracking.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponTracking.cs
@@ -52,7 +52,7 @@ namespace CoreSystems.Platform
 
             bool selfHit = false;
             weapon.LastHitInfo = null;
-            if (checkSelfHit && target != null && !weapon.ActiveAmmoDef.AmmoDef.Const.SkipRayChecks)
+            if (checkSelfHit && target != null && !weapon.ActiveAmmoDef.AmmoDef.Const.SkipRayChecks && !weapon.ActiveAmmoDef.AmmoDef.IgnoreGrids)
             {
                 var testLine = new LineD(targetCenter, weapon.BarrelOrigin);
                 var predictedMuzzlePos = testLine.To + (-testLine.Direction * weapon.MuzzleDistToBarrelCenter);
@@ -885,6 +885,9 @@ namespace CoreSystems.Platform
 
         public bool MuzzleHitSelf()
         {
+            if (ActiveAmmoDef.AmmoDef.IgnoreGrids)
+                return false;
+
             for (int i = 0; i < Muzzles.Length; i++)
             {
                 var m = Muzzles[i];

--- a/Data/Scripts/CoreSystems/Session/SessionUpdate.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionUpdate.cs
@@ -154,7 +154,8 @@ namespace CoreSystems
 
                         var reloading = p.ActiveAmmoDef.AmmoDef.Const.Reloadable && p.ClientMakeUpShots == 0 && (p.Loading || p.ProtoWeaponAmmo.CurrentAmmo == 0);
                         var overHeat = p.PartState.Overheated && p.OverHeatCountDown == 0;
-                        var canShoot = !overHeat && !reloading;
+                        var needsHeat = p.ActiveAmmoDef.AmmoDef.HeatNeededToFire > 0 && p.PartState.Heat < p.ActiveAmmoDef.AmmoDef.HeatNeededToFire;
+                        var canShoot = !overHeat && !reloading && !needsHeat;
 
                         var autoShot = pComp.Data.Repo.Values.State.Trigger == On || p.AiShooting && pComp.Data.Repo.Values.State.Trigger == Off;
                         var anyShot = !pComp.ShootManager.FreezeClientShoot && (p.ShootCount > 0 || onConfrimed) && noShootDelay || autoShot && sMode == Weapon.ShootManager.ShootModes.AiShoot;
@@ -763,8 +764,9 @@ namespace CoreSystems
 
                         var reloading = aConst.Reloadable && w.ClientMakeUpShots == 0 && (w.Loading || noAmmo || w.Reload.WaitForClient);
                         var overHeat = w.PartState.Overheated && (w.OverHeatCountDown == 0 || w.OverHeatCountDown != 0 && w.OverHeatCountDown-- == 0);
+                        var needsHeat = w.ActiveAmmoDef.AmmoDef.HeatNeededToFire > 0 && w.PartState.Heat < w.ActiveAmmoDef.AmmoDef.HeatNeededToFire;
 
-                        var canShoot = !overHeat && !reloading && !w.System.DesignatorWeapon && sequenceReady;
+                        var canShoot = !overHeat && !reloading && !w.System.DesignatorWeapon && sequenceReady && !needsHeat;
                         var paintedTarget = wComp.PainterMode && w.Target.TargetState == TargetStates.IsFake && (w.Target.IsAligned || ai.ControlComp != null && ai.ControlComp.Platform.Control.IsAimed);
                         var autoShot = paintedTarget || w.AiShooting && wValues.State.Trigger == Off;
                         var anyShot = !wComp.ShootManager.FreezeClientShoot && (w.ShootCount > 0 || onConfrimed) && noShootDelay || autoShot && sMode == Weapon.ShootManager.ShootModes.AiShoot;

--- a/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
+++ b/Data/Scripts/CoreSystems/Ui/Hud/HudDraw.cs
@@ -326,7 +326,7 @@ namespace WeaponCore.Data.Scripts.CoreSystems.Ui.Hud
         private void HasHeat(Weapon weapon, StackedWeaponInfo stackedInfo, ref Vector2D currWeaponDisplayPos, bool reset)
         {
             int heatBarIndex;
-            if (weapon.PartState.Overheated)
+            if (weapon.PartState.Overheated || (weapon.HeatPerc >= 0.95f && weapon.System.WConst.DisableOverheat))
             {
                 var index = Session.I.SCount < 30 ? 1 : 2;
                 heatBarIndex = HeatBarTexture.Length - 2;


### PR DESCRIPTION
- Makes prohibit HUD painter remove the terminal controls/actions pertaining to it
  - Tested in SP and on DS (mostly a clientside fix)
- Add int `AmmoDef.HeatNeededToFire`
  - Makes an ammo require heat in order to be able to be fired.
  - With DisableOverheat and AllowNegativeHeatModifier you can turn heat into a powerup bar to be spent on more powerful ammos which subtract heat, or make certain ammos only available on high heat levels.
  - It should be noted that this does NOT subtract the heat, use `AmmoDef.AllowNegativeHeatModifier` to subtract the desired amount.
  - This still needs some sort of terminal display for why the weapon won't fire if this happens.
  - Tested in SP but should be fine on DS
- Add bool `WeaponDefinition.HardPointDef.LoadingDef.DisableOverheat`
  - Disables weapon overheating, but keeps DegradeRof. Useful if you want DegradeRof but want the weapon to keep shooting even at max heat.
  - (At some point I want to make the heat bar when this happens white rather than red but idk how to texture and don't really want to find out.)
  - Tested in SP but should be fine on DS
- Add bool `AmmoDef.AllowNegativeHeatModifier`
  - Bypasses ammo.AmmoDef.HeatModifier > 0 check to allow ammo types to reduce heat on weapons. Done this way to preserve backwards compatibility.
  - Useful for having ammo types that take away rather than give heat.
- Add bool `AmmoDef.AmmoAudioDef.OverrideShotSound`
  - When true, will use the ammo's ShotSound regardless of the given weapon's shot sound.
  - Technically this can already be done with weapon sound set to an empty string w/ all ammos setting theirs but this would make it easier for "special ammos" to have a special sfx on multiple weapons with different shot sounds (this also wasn't notated anywhere).
  - Tested in SP but should be fine on DS
- Add bool `AmmoDef.IgnoreGrids`
  - Disables collisions with grid and defense shields. Designed for fragments designed to time things (where a grid could disrupt) or for anti projectile weapons being able to fire through grids.
  - While this allows weapons to fire through their own grids, they will not automatically do so (because raycast checks only return the nearest hit entity, and skipping ray checks could result in the weapon trying to fire through voxels when it shouldn't). 
  - (I don't feel like figuring out a solution that doesn't use the raycast function which returns all hit entities. Changes in WeaponTracking relating to this were trying to fix this but keeping them in is a small performance boost.)
  - Tested in SP but should be fine on DS
- Add struct `WeaponDefinition.HardPointDef.LoadingDef.DegradeSettingsDef` and a `DegradeSettingsDef` field to `WeaponDefinition.HardPointDef.LoadingDef`|
  - if DegradeRof is active (heat went above `HeatThresholdStart` and has not went below `HeatThresholdEnd`, and `Loading.DegradeRof = true`), then multiply rof by a linear interpolation between RofAt0Heat and RofAt100Heat, using CurrentHeat/MaxHeat as the value.
  - Add float `HeatThresholdStart` - Heat percentage where DegradeRof activates, until heat percentage goes below `HeatThresholdEnd`; mustbe between 0.00001f and 1f or it defaults to 0.8f
  - Add float `HeatThresholdEnd` - Heat percentage where DegradeRof ends, until heat percentage goes back above `HeatThresholdStart`; must be between 0.00001f and 1f or it defaults to 0.4f
  - Add float `RofAt0Heat` - ROF multiplier when DegradeRof is active, if heat was at 0%, NOT when it is at the start threshold; must be greater than 0 or it defaults to 1f
  - Add float `RofAt100Heat` - ROF multiplier when DegradeRof is active, if heat was at 100%, NOT when it is at the end threshold; must be greater than 0 or it defaults to 0.25f
  - Tested in SP but should be fine on DS
- Implement GetMaxPower in the API (was todo)
  - Tested in SP but should be fine on DS
- Add float `WeaponDefinition.HardPointDef.LoadingDef.HeatSinkRateOverheatMult`
  - Multiplier to `LoadingDef.HeatSinkRate` when the weapon is overheated. 0 disables, negative values are allowed. Beware this makes a weapon unusable should it overheat if it doesn't also have negative `LoadingDef.HeatSinkRate`, which does not work properly at the moment (heat does not update unless it has heat).
  - Tested in SP but should be fine on DS
  
New stuff will need to be added to CoreParts. Descriptions put here should be sufficient for the comments.

I should also mention that the new stuff bricks DPS calcs if used... I don't even want to know how cancer that will be to fix.