### PR TITLE
Re-remove the vanilla replacer hardcode.

### DIFF
--- a/Data/Scripts/CoreSystems/Session/SessionFields.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionFields.cs
@@ -55,6 +55,7 @@ namespace CoreSystems
         internal const string ServerCfgName = "CoreSystemsServer.cfg";
         internal const string ClientCfgName = "CoreSystemsClient.cfg";
         internal static Session I;
+        internal volatile bool LogInit;
         internal volatile bool Inited;
         internal volatile bool TurretControls;
         internal volatile bool FixedMissileControls;
@@ -254,6 +255,7 @@ namespace CoreSystems
         internal readonly HashSet<MyDefinitionId> CoreSystemsPhantomDefs = new HashSet<MyDefinitionId>();
         internal readonly HashSet<ArmorDefinition> CoreSystemsArmorDefs = new HashSet<ArmorDefinition>();
         internal readonly HashSet<string> VanillaSubtypes = new HashSet<string>();
+        internal readonly Dictionary<string, string> VanillaPartNames = new Dictionary<string, string>();
         internal readonly HashSet<MyStringHash> PerformanceWarning = new HashSet<MyStringHash>();
         internal readonly HashSet<Ai> GridsToUpdateInventories = new HashSet<Ai>();
         internal readonly List<MyCubeGrid> DirtyGridsTmp = new List<MyCubeGrid>(10);

--- a/Data/Scripts/CoreSystems/Session/SessionInit.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionInit.cs
@@ -125,17 +125,7 @@ namespace CoreSystems
         {
             if (Inited) return;
             Inited = true;
-            Log.Init("debug", this);
-            Log.Init("perf", this, false);
-            Log.Init("stats", this, false);
-            Log.Init("net", this, false);
-            Log.Init("report", this, false);
-            Log.Init("combat", this, false);
-            Log.Init("ammostats", this, false);
-            Log.Init("wepstats", this, false);
-            Log.Init("dmgstats", this, false);
-            Log.Init("griddmgstats", this, false);
-            Log.Init(InputLog, this, false);
+            
             MpActive = MyAPIGateway.Multiplayer.MultiplayerActive;
             IsServer = MyAPIGateway.Multiplayer.IsServer;
             DedicatedServer = MyAPIGateway.Utilities.IsDedicated;
@@ -324,6 +314,9 @@ namespace CoreSystems
                         }
                         if (prevPrio >= x.HardPoint.DefinitionPriority)
                         {
+                            var prevName = prevDef.ModPath.Split('\\');
+                            var wepName = x.ModPath.Split('\\');
+                            Log.Line($"WeaponDef '{x.HardPoint.PartName}' has a definition with a higher priority present for {mount.SubtypeId}! current prio: {prevPrio} --> attempted prio: {x.HardPoint.DefinitionPriority}, current mod: {prevName[prevName.Length - 1]}, attempted mod: {wepName[wepName.Length - 1]}", "debug");
                             continue;
                         }
                         if (prevDef != null)
@@ -341,7 +334,7 @@ namespace CoreSystems
                             var prevName = prevDef.ModPath.Split('\\');
                             var wepName = x.ModPath.Split('\\');
                             
-                            Log.Stats($"WeaponDef '{x.HardPoint.PartName}' was overriden for {mount.SubtypeId}! prev prio: {prevPrio} --> new prio: {x.HardPoint.DefinitionPriority}, old mod: {prevName[prevName.Length-1]}, new mod: {wepName[wepName.Length-1]}", "debug");
+                            Log.Line($"WeaponDef '{x.HardPoint.PartName}' was overriden for {mount.SubtypeId}! prev prio: {prevPrio} --> new prio: {x.HardPoint.DefinitionPriority}, old mod: {prevName[prevName.Length-1]}, new mod: {wepName[wepName.Length-1]}", "debug");
                         }
 
                         _subTypeMaps[subTypeId][partAttachmentId] = extraInfo;

--- a/Data/Scripts/CoreSystems/Session/SessionModHandlers.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionModHandlers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using CoreSystems.Support;
 using Sandbox.Definitions;
 using Sandbox.ModAPI;
@@ -141,10 +142,62 @@ namespace CoreSystems
         {
             foreach (var wepDef in partDefs)
             {
-                WeaponDefinitions.Add(wepDef);
+                for (int i = wepDef.Assignments.MountPoints.Length - 1; i >= 0; i--)
+                {
+                    var subtypeID = wepDef.Assignments.MountPoints[i].SubtypeId;
+                    subTypes.Add(subtypeID);
 
-                for (int i = 0; i < wepDef.Assignments.MountPoints.Length; i++)
-                    subTypes.Add(wepDef.Assignments.MountPoints[i].SubtypeId);
+
+                    // old vanilla replacer compat... aaaaaaaaaaaaaaaaaaaaaaaaaaa
+                    string partName;
+                    if (VanillaPartNames.TryGetValue(subtypeID, out partName)
+                        && (partName != wepDef.HardPoint.PartName || wepDef.HardPoint.HardWare.Type != WeaponDefinition.HardPointDef.HardwareDef.HardwareType.BlockWeapon))
+                    {
+                        Log.Line($"WeaponDef '{wepDef.HardPoint.PartName}' has the vanilla subtype {subtypeID} with: {(partName != wepDef.HardPoint.PartName ? "a different part name," : "")}{(wepDef.HardPoint.HardWare.Type != WeaponDefinition.HardPointDef.HardwareDef.HardwareType.BlockWeapon ? "a weapon type not equal to BlockWeapon," : "")}. Setting partname to {partName} and Type to BlockWeapon and generating a new weapon definition!", "debug");
+                        var mount = wepDef.Assignments.MountPoints[i];
+
+                        var newArr = new WeaponDefinition.ModelAssignmentsDef.MountPointDef[wepDef.Assignments.MountPoints.Length - 1];
+                        if (wepDef.Assignments.MountPoints.Length > 1)
+                        {
+                            Array.Copy(wepDef.Assignments.MountPoints, 0, newArr, 0, i);
+                            Array.Copy(wepDef.Assignments.MountPoints, i + 1, newArr, i, wepDef.Assignments.MountPoints.Length - i - 1);
+                            wepDef.Assignments.MountPoints = newArr;
+                        }
+                        else
+                        {
+                            wepDef.Assignments.MountPoints = new WeaponDefinition.ModelAssignmentsDef.MountPointDef[0];
+                        }
+
+                        var newDef = new WeaponDefinition
+                        {
+                            Assignments = new WeaponDefinition.ModelAssignmentsDef
+                            {
+                                MountPoints = new[]
+                                    {
+                                    mount
+                                },
+                                Ejector = wepDef.Assignments.Ejector,
+                                Muzzles = wepDef.Assignments.Muzzles,
+                                Scope = wepDef.Assignments.Scope,
+                            },
+                            HardPoint = wepDef.HardPoint,
+                            Upgrades = wepDef.Upgrades,
+                            Targeting = wepDef.Targeting,
+                            ModPath = wepDef.ModPath,
+                            Animations = wepDef.Animations,
+                            Ammos = wepDef.Ammos,
+                        };
+                        newDef.HardPoint.PartName = partName;
+                        newDef.HardPoint.HardWare.Type = WeaponDefinition.HardPointDef.HardwareDef.HardwareType.BlockWeapon;
+                        WeaponDefinitions.Add(newDef);
+
+                    }
+                }
+
+                if (wepDef.Assignments.MountPoints.Length > 0)
+                {
+                    WeaponDefinitions.Add(wepDef);
+                }
             }
         }
 

--- a/Data/Scripts/CoreSystems/Session/SessionRun.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionRun.cs
@@ -361,6 +361,22 @@ namespace CoreSystems
                     searchLight.MaxRangeMeters = 0.1f;
             }
 
+            if (!LogInit)
+            {
+                LogInit = true;
+                Log.Init("debug", this);
+                Log.Init("perf", this, false);
+                Log.Init("stats", this, false);
+                Log.Init("net", this, false);
+                Log.Init("report", this, false);
+                Log.Init("combat", this, false);
+                Log.Init("ammostats", this, false);
+                Log.Init("wepstats", this, false);
+                Log.Init("dmgstats", this, false);
+                Log.Init("griddmgstats", this, false);
+                Log.Init(InputLog, this, false);
+            }
+
             ModChecker();
 
             if (SuppressWc)

--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -1130,8 +1130,6 @@ namespace CoreSystems
                 DebugMod = true;
             }
 
-            bool ReplaceVanilla = false;
-
             foreach (var mod in Session.Mods)
             {
                 var modPath = mod.GetPath();
@@ -1148,13 +1146,11 @@ namespace CoreSystems
                     WaterMod = true;
                 else if (mod.PublishedFileId == 3514216428 || mod.GetPath().Contains("AppData\\Roaming\\SpaceEngineers\\Mods\\NerdShieldsFramework"))
                     NerdShieldMod = true;
-                else if (mod.PublishedFileId == 1931509062)
-                    ReplaceVanilla = true;
             }
 
             SuppressWc = LocalVersion ? false : !SUtils.ModActivate(ModContext, Session);
 
-            if (!SuppressWc && !ReplaceVanilla)
+            if (!SuppressWc)
             {
                 ContainerDefinition baseDefs;
                 Parts.GetBaseDefinitions(out baseDefs);
@@ -1162,18 +1158,22 @@ namespace CoreSystems
                 {
                     Parts.SetModPath(baseDefs, ModContext.ModPath);
                     PickDef(baseDefs);
+
+                    if (baseDefs.WeaponDefs != null)
+                    {
+                        foreach (var wep in baseDefs.WeaponDefs)
+                        {
+                            foreach (var subtype in wep.Assignments.MountPoints)
+                            {
+                                VanillaPartNames[subtype.SubtypeId] = wep.HardPoint.PartName;
+                            }
+                        }
+                    }
                 }
             }
-            else if (ReplaceVanilla)
-            {
-                ContainerDefinition baseDefs;
-                Parts.GetBaseDefinitions(out baseDefs);
-
-                if (baseDefs.ProjectileTags != null)
-                    AssembleTagDefinitions(baseDefs.ProjectileTags);
-            }
-
         }
+
+        
         public string ModPath()
         {
             var modPath = ModContext.ModPath;


### PR DESCRIPTION
- Move log start to LoadData from Init (needed because I'm logging stuff in debug in LoadData)
- Vanilla replacer support should be more robust with the definition priority system to not crash with several vanilla replacers
- vanilla weapons can only suppodwHandWeapons with a subtype equal to a vanilla block weapon will have their Type set to BlockWeapon too.

Tested with NW vanilla and Nukeguard's vanilla weapons + at the same time, load order decides which one's stats are used instead of crashing.