### PR TITLE
Drone Additions

### DIFF
--- a/Data/Scripts/CoreSystems/Ai/AiTargeting.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiTargeting.cs
@@ -837,7 +837,7 @@ namespace CoreSystems.Support
                     else
                     {
                         Vector3D? hitInfo;
-                        if (ai.AiType == AiTypes.Grid && GridIntersection.BresenhamGridIntersection(ai.GridEntity, ref weaponPos, ref lp.Position, out hitInfo, w.Comp.Cube, ai))
+                        if (ai.AiType == AiTypes.Grid && !w.System.Values.HardPoint.Other.DisableOwnGridLosCheck && GridIntersection.BresenhamGridIntersection(ai.GridEntity, ref weaponPos, ref lp.Position, out hitInfo, w.Comp.Cube, ai))
                         {
                             if (isFromManager)
                             {
@@ -1216,6 +1216,10 @@ namespace CoreSystems.Support
                         target.Set(lp, lp.Position,  0, 0, long.MaxValue);
                         p.TargetPosition = lp.Position;
                         lp.Seekers.Add(p);
+                        if (aConst.Health > 0 && lp.Info.AmmoDef.Const.GridsTargetSeekersTargetingThis)
+                        {
+                            session.Projectiles.AddProjectileTargets(p);
+                        }
                         found = true;
                         break;
                     }
@@ -1229,6 +1233,10 @@ namespace CoreSystems.Support
                     target.Set(lp, lp.Position, 0, 0, long.MaxValue);
                     p.TargetPosition = lp.Position;
                     lp.Seekers.Add(p);
+                    if (aConst.Health > 0 && lp.Info.AmmoDef.Const.GridsTargetSeekersTargetingThis)
+                    {
+                        session.Projectiles.AddProjectileTargets(p);
+                    }
                     found = true;
                     break;
                 }

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -689,6 +689,8 @@ namespace CoreSystems.Support
                 [ProtoMember(12)] internal bool ProhibitLGTargeting;
                 [ProtoMember(13)] internal bool ProhibitSGTargeting;
                 [ProtoMember(14)] internal bool ProhibitSubsystemChanges;
+                [ProtoMember(15)] internal bool DisableOwnGridLosCheck;
+                [ProtoMember(16)] internal bool AllowNoTargetFiring;
             }
 
             [ProtoContract]
@@ -738,7 +740,7 @@ namespace CoreSystems.Support
             [ProtoMember(34)] internal bool IgnoreGrids;
             [ProtoMember(35)] internal bool AllowNegativeHeatModifier;
             [ProtoMember(36)] internal int HeatNeededToFire;
-
+            [ProtoMember(37)] internal bool GridsTargetSeekersTargetingThis;
 
             [ProtoContract]
             public struct SynchronizeDef
@@ -1464,6 +1466,9 @@ namespace CoreSystems.Support
                         DistanceToTarget,
                         DistanceFromEndTrajectory,
                         DistanceToEndTrajectory,
+                        ReaquiredTarget,
+                        EnemySeekersGreaterThanEqualTo,
+                        EnemySeekersLessThanEqualTo,
                     }
 
                     public enum UpRelativeTo
@@ -1536,6 +1541,7 @@ namespace CoreSystems.Support
                         StorePositionA,
                         StorePositionB,
                         StorePositionC,
+                        ForceRetarget,
                     }
 
                     [ProtoContract]
@@ -1548,6 +1554,8 @@ namespace CoreSystems.Support
                         [ProtoMember(4)] public double End2WeightMod;
                         [ProtoMember(5)] public int MaxRuns;
                         [ProtoMember(6)] public double End3WeightMod;
+                        [ProtoMember(7)] public double End4WeightMod;
+                        [ProtoMember(8)] public double End5WeightMod;
                     }
 
                     [ProtoMember(1)] internal ReInitCondition RestartCondition;
@@ -1617,6 +1625,10 @@ namespace CoreSystems.Support
                     [ProtoMember(65)] internal double End3Value;
                     [ProtoMember(66)] internal bool SwapNavigationType;
                     [ProtoMember(67)] internal bool ElevationRelativeToC;
+                    [ProtoMember(68)] internal Conditions EndCondition4;
+                    [ProtoMember(69)] internal double End4Value;
+                    [ProtoMember(70)] internal Conditions EndCondition5;
+                    [ProtoMember(71)] internal double End5Value;
                 }
 
                 [ProtoContract]

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -259,6 +259,7 @@ namespace CoreSystems.Support
         public readonly bool ProjectilesFirst;
         public readonly bool OverrideWeaponEffect;
         public readonly bool IgnoreAntiSmarts;
+        public readonly bool GridsTargetSeekersTargetingThis;
         public readonly float LargeGridDmgScale;
         public readonly float SmallGridDmgScale;
         public readonly float CharacterDmgScale;
@@ -430,7 +431,7 @@ namespace CoreSystems.Support
 
             ComputeSmarts(ammo, out IsSmart, out Roam, out NoTargetApproach, out AccelClearance, out OverrideTarget, out TargetOffSet,
                 out FocusOnly, out FocusEviction, out NoSteering, out AdvancedSmartSteering, out KeepAliveAfterTargetLoss, out NoTargetExpire, out ZeroEffortNav, out ScanRangeSqr, out OffsetMinRangeSqr,
-                out Aggressiveness, out NavAcceleration, out MinTurnSpeedSqr, out OffsetRatio, out MaxChaseTime, out MaxTargets, out OffsetTime, out IgnoreAntiSmarts);
+                out Aggressiveness, out NavAcceleration, out MinTurnSpeedSqr, out OffsetRatio, out MaxChaseTime, out MaxTargets, out OffsetTime, out IgnoreAntiSmarts, out GridsTargetSeekersTargetingThis);
 
             IsGuided = TravelTo || IsMine || IsDrone || IsSmart;
 
@@ -659,7 +660,7 @@ namespace CoreSystems.Support
 
         private void ComputeSmarts(WeaponSystem.AmmoType ammo, out bool isSmart, out bool roam, out bool noTargetApproach, out bool accelClearance, out bool overrideTarget, out bool targetOffSet,
             out bool focusOnly, out bool focusEviction, out bool noSteering, out bool advancedSmartSteering, out bool keepAliveAfterTargetLoss, out bool noTargetExpire, out bool zeroEffortNav, out double scanRangeSqr, out double offsetMinRangeSqr,
-            out double aggressiveness, out double navAcceleration, out double minTurnSpeedSqr, out float offsetRatio, out int maxChaseTime, out int maxTargets, out int offsetTime, out bool ignoreAntiSmarts)
+            out double aggressiveness, out double navAcceleration, out double minTurnSpeedSqr, out float offsetRatio, out int maxChaseTime, out int maxTargets, out int offsetTime, out bool ignoreAntiSmarts, out bool gridsTargetSeekersTargetingThis)
         {
             isSmart = ammo.AmmoDef.Trajectory.Guidance == TrajectoryDef.GuidanceType.Smart || ammo.AmmoDef.Trajectory.Guidance == TrajectoryDef.GuidanceType.DetectSmart;
 
@@ -695,6 +696,8 @@ namespace CoreSystems.Support
             noTargetApproach = ammo.AmmoDef.Trajectory.Smarts.NoTargetApproach;
             zeroEffortNav = ammo.AmmoDef.Trajectory.Smarts.AltNavigation;
             ignoreAntiSmarts = ammo.AmmoDef.Trajectory.Smarts.IgnoreAntiSmarts;
+
+            gridsTargetSeekersTargetingThis = ammo.AmmoDef.GridsTargetSeekersTargetingThis && ammo.AmmoDef.Health > 0;
         }
 
 
@@ -1910,6 +1913,8 @@ namespace CoreSystems.Support
         public readonly TrajectoryDef.ApproachDef.Conditions EndCon1;
         public readonly TrajectoryDef.ApproachDef.Conditions EndCon2;
         public readonly TrajectoryDef.ApproachDef.Conditions EndCon3;
+        public readonly TrajectoryDef.ApproachDef.Conditions EndCon4;
+        public readonly TrajectoryDef.ApproachDef.Conditions EndCon5;
         public readonly bool AdjustForward;
         public readonly bool AdjustUp;
         public readonly bool DisableAvoidance;
@@ -1945,6 +1950,8 @@ namespace CoreSystems.Support
         public readonly double End1Value;
         public readonly double End2Value;
         public readonly double End3Value;
+        public readonly double End4Value;
+        public readonly double End5Value;
         public readonly double ElevationTolerance;
 
         public readonly int OffsetTime;
@@ -1985,6 +1992,8 @@ namespace CoreSystems.Support
             EndCon1 = def.EndCondition1;
             EndCon2 = def.EndCondition2;
             EndCon3 = def.EndCondition3;
+            EndCon4 = def.EndCondition4;
+            EndCon5 = def.EndCondition5;
             AdjustForward = def.AdjustForward;
             AdjustUp = def.AdjustUp;
             Orbit = def.Orbit;
@@ -2008,6 +2017,8 @@ namespace CoreSystems.Support
             End1Value = def.End1Value;
             End2Value = def.End2Value;
             End3Value = def.End3Value;
+            End4Value = def.End4Value;
+            End5Value = def.End5Value;
             TrackingDistance = def.TrackingDistance;
             LeadDistance = def.LeadDistance;
             AccelMulti = def.AccelMulti;
@@ -2066,7 +2077,7 @@ namespace CoreSystems.Support
             }
         }
 
-        public int GetRestartId(ProInfo info, bool end1, bool end2, bool end3)
+        public int GetRestartId(ProInfo info, bool end1, bool end2, bool end3, bool end4, bool end5)
         {
             var array = Definition.RestartList;
             
@@ -2085,43 +2096,31 @@ namespace CoreSystems.Support
                     if (runCount >= item.MaxRuns && item.MaxRuns > 0)
                         continue;
 
+                    var forced = end1 && item.End1WeightMod == double.MaxValue || end2 && item.End2WeightMod == double.MaxValue || end3 && item.End3WeightMod == double.MaxValue || end4 && item.End4WeightMod == double.MaxValue || end5 && item.End5WeightMod == double.MaxValue;
+                    if (forced)
+                    {
+                        highestRoll = 1;
+                        rngSelectedId = item.ApproachId;
+                        break;
+                    }
+
+                    
                     var mod1Enabled = end1 && !MyUtils.IsZero(item.End1WeightMod);
                     var mod2Enabled = end2 && !MyUtils.IsZero(item.End2WeightMod);
                     var mod3Enabled = end3 && !MyUtils.IsZero(item.End3WeightMod);
+                    var mod4Enabled = end4 && !MyUtils.IsZero(item.End4WeightMod);
+                    var mod5Enabled = end5 && !MyUtils.IsZero(item.End5WeightMod);
 
-                    float rng;
-                    if (mod1Enabled && mod2Enabled && mod3Enabled)
-                    {
-                        var rng1 = (float)info.Random.Range(item.Weight.Start * item.End1WeightMod, item.Weight.End * item.End1WeightMod);
-                        var rng2 = (float)info.Random.Range(item.Weight.Start * item.End2WeightMod, item.Weight.End * item.End2WeightMod);
-                        var rng3 = (float)info.Random.Range(item.Weight.Start * item.End3WeightMod, item.Weight.End * item.End3WeightMod);
-                        rng = Math.Max(rng1, Math.Max(rng2, rng3));
-                    }
-                    else if (mod1Enabled && mod3Enabled)
-                    {
-                        var rng1 = (float)info.Random.Range(item.Weight.Start * item.End1WeightMod, item.Weight.End * item.End1WeightMod);
-                        var rng3 = (float)info.Random.Range(item.Weight.Start * item.End3WeightMod, item.Weight.End * item.End3WeightMod);
-                        rng = Math.Max(rng1, rng3);
-                    }
-                    else if (mod2Enabled && mod3Enabled)
-                    {
-                        var rng2 = (float)info.Random.Range(item.Weight.Start * item.End2WeightMod, item.Weight.End * item.End2WeightMod);
-                        var rng3 = (float)info.Random.Range(item.Weight.Start * item.End3WeightMod, item.Weight.End * item.End3WeightMod);
-                        rng = Math.Max(rng2, rng3);
-                    }
-                    else if (mod1Enabled && mod2Enabled) {
-                        var rng1 = (float)info.Random.Range(item.Weight.Start * item.End1WeightMod, item.Weight.End * item.End1WeightMod);
-                        var rng2 = (float)info.Random.Range(item.Weight.Start * item.End2WeightMod, item.Weight.End * item.End2WeightMod);
-                        rng = Math.Max(rng1, rng2);
-                    }
-                    else if (mod1Enabled)
-                        rng = (float) info.Random.Range(item.Weight.Start * item.End1WeightMod, item.Weight.End * item.End1WeightMod);
-                    else if (mod2Enabled)
-                        rng = (float)info.Random.Range(item.Weight.Start * item.End2WeightMod, item.Weight.End * item.End2WeightMod);
-                    else if (mod3Enabled)
-                        rng = (float)info.Random.Range(item.Weight.Start * item.End3WeightMod, item.Weight.End * item.End3WeightMod);
-                    else 
-                        rng = info.Random.Range(item.Weight.Start, item.Weight.End);
+                    // beygone if statement horde
+                    float rng = mod1Enabled || mod2Enabled || mod3Enabled || mod4Enabled ? info.Random.Range(item.Weight.Start, item.Weight.End) : float.MinValue;
+                    var rng1 = mod1Enabled ? (float)info.Random.Range(item.Weight.Start * item.End1WeightMod, item.Weight.End * item.End1WeightMod) : float.MinValue;
+                    var rng2 = mod2Enabled ? (float)info.Random.Range(item.Weight.Start * item.End2WeightMod, item.Weight.End * item.End2WeightMod) : float.MinValue;
+                    var rng3 = mod3Enabled ? (float)info.Random.Range(item.Weight.Start * item.End3WeightMod, item.Weight.End * item.End3WeightMod) : float.MinValue;
+                    var rng4 = mod4Enabled ? (float)info.Random.Range(item.Weight.Start * item.End4WeightMod, item.Weight.End * item.End4WeightMod) : float.MinValue;
+                    var rng5 = mod5Enabled ? (float)info.Random.Range(item.Weight.Start * item.End5WeightMod, item.Weight.End * item.End5WeightMod) : float.MinValue;
+
+                    if (mod1Enabled || mod2Enabled || mod3Enabled || mod4Enabled || mod5Enabled)
+                        rng = Math.Max(rng, Math.Max(rng1, Math.Max(rng2, Math.Max(rng3, Math.Max(rng4, rng5)))));
 
                     if (rng > highestRoll)
                     {

--- a/Data/Scripts/CoreSystems/EntityComp/Controls/Weapon/WeaponActions.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Controls/Weapon/WeaponActions.cs
@@ -116,7 +116,7 @@ namespace CoreSystems.Control
             var mode = comp.Data.Repo.Values.Set.Overrides.ShootMode;
             if (mode == Weapon.ShootManager.ShootModes.KeyToggle || mode == Weapon.ShootManager.ShootModes.KeyFire)
             {
-                if (!comp.Data.Repo.Values.Set.Overrides.Override && comp.HasRequireTarget && comp.PrimaryWeapon.Target.CurrentState != Target.States.Acquired)
+                if (!comp.Data.Repo.Values.Set.Overrides.Override && !comp.PrimaryWeapon.System.Values.HardPoint.Other.AllowNoTargetFiring && comp.HasRequireTarget && comp.PrimaryWeapon.Target.CurrentState != Target.States.Acquired)
                     return;
                 var keyToggle = mode == Weapon.ShootManager.ShootModes.KeyToggle;
                 var signal = keyToggle ? Weapon.ShootManager.Signals.KeyToggle : Weapon.ShootManager.Signals.Once;

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponComp.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponComp.cs
@@ -317,7 +317,7 @@ namespace CoreSystems.Platform
                     if (sequence.Weapons.Count > 1 && sequence.Weapons.ContainsKey(this))
                         return false;
 
-                    var working = IsFunctional && IsWorking && (!TurretController || MasterOverrides.Override || ModOverride || PartTracking == Collection.Count);
+                    var working = IsFunctional && IsWorking && (!TurretController || MasterOverrides.Override || PrimaryWeapon.System.Values.HardPoint.Other.AllowNoTargetFiring || ModOverride || PartTracking == Collection.Count);
 
                     if (ShootManager.LastShootTick > ShootManager.PrevShootEventTick || !working)
                     {

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponTracking.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponTracking.cs
@@ -1486,7 +1486,7 @@ namespace CoreSystems.Platform
 
         public bool MuzzleHitSelf()
         {
-            if (ActiveAmmoDef.AmmoDef.IgnoreGrids)
+            if (ActiveAmmoDef.AmmoDef.IgnoreGrids || System.Values.HardPoint.Other.DisableOwnGridLosCheck)
                 return false;
 
             for (int i = 0; i < Muzzles.Length; i++)

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using CoreSystems.Support;
 using Jakaria.API;
 using Sandbox.Game.Entities;
+using Sandbox.ModAPI;
 using Sandbox.ModAPI.Ingame;
 using VRage.Game;
 using VRage.Game.Components;
@@ -184,6 +185,10 @@ namespace CoreSystems.Projectiles
                     HadTarget = HadTargetState.Projectile;
                     TargetPosition = tTarget.Position;
                     tTarget.Seekers.Add(this);
+                    if (Info.AmmoDef.Const.Health > 0 && (tTarget.Info?.AmmoDef?.Const?.GridsTargetSeekersTargetingThis ?? false))
+                    {
+                        session.Projectiles.AddProjectileTargets(this);
+                    }
                     break;
                 case Target.TargetStates.IsFake:
                     TargetPosition = Info.IsFragment ? TargetPosition : Vector3D.Zero;
@@ -431,6 +436,11 @@ namespace CoreSystems.Projectiles
 
             for (int i = 0; i < Watchers.Count; i++) Watchers[i].DeadProjectiles.Add(this);
             Watchers.Clear();
+
+            if (Info.Target.TargetObject != null && Info.Target.TargetObject is Projectile)
+            {
+                ((Projectile)Info.Target.TargetObject)?.Seekers.Remove(this);
+            }
 
             foreach (var seeker in Seekers)
             {
@@ -926,8 +936,9 @@ namespace CoreSystems.Projectiles
 
                 var approach = aConst.Approaches[storage.RequestedStage];
 
-                if (approach.StartCon1 == approach.StartCon2 || approach.EndCon1 == approach.EndCon2)
-                    return; // bad modder, failed to read coreparts comment, fail silently so they drive themselves nuts
+                // unneeded branch
+                //if (approach.StartCon1 == approach.StartCon2 || approach.EndCon1 == approach.EndCon2)
+                //    return; // bad modder, failed to read coreparts comment, fail silently so they drive themselves nuts
 
                 disableAvoidance = approach.DisableAvoidance;
 
@@ -1020,7 +1031,7 @@ namespace CoreSystems.Projectiles
                             aInfo.OffsetUpDir = !Vector3D.IsZero(PrevTargetVel) ? Vector3D.Normalize(PrevTargetVel) : Info.OriginUp;
                             break;
                         case UpRelativeTo.UpOriginDirection:
-                            aInfo.OffsetUpDir = Info.OriginFwd;
+                            aInfo.OffsetUpDir = Info.OriginUp;
                             break;
                         case UpRelativeTo.UpStoredStartDontUse:
                         case UpRelativeTo.UpStoredStartPosition:
@@ -1055,7 +1066,7 @@ namespace CoreSystems.Projectiles
 
                 if (approach.HasAngleOffset)
                 {
-                    if (stageChange && approach.ModAngleOffset) 
+                    if (stageChange && approach.ModAngleOffset)
                     {
                         var min = approach.Definition.AngleVariance.Start;
                         var max = approach.Definition.AngleVariance.End;
@@ -1229,232 +1240,8 @@ namespace CoreSystems.Projectiles
                 var elStartLineB = positionB + heightOffset;
                 double timeSinceSpawn = double.MinValue;
                 double nextSpawn = double.MinValue;
-                bool start1 = false;
-                
-
-                switch (approach.StartCon1)
-                {
-                    case Conditions.DesiredElevation:
-                        var plane = new PlaneD(aInfo.PositionB, aInfo.OffsetUpDir);
-                        var distToPlane = approach.Elevation != RelativeTo.Surface ? Math.Abs(plane.DistanceToPoint(Position)) : plane.DistanceToPoint(Position);
-                        var tolernace = approach.ElevationTolerance + aConst.CollisionSize;
-                        var distFromSurfaceSqr = !Vector3D.IsZero(surfacePos) ? Vector3D.DistanceSquared(Position, surfacePos) : distToPlane * distToPlane;
-                        var lessThanTolerance = (approach.Start1Value + tolernace) * (approach.Start1Value + tolernace);
-                        var greaterThanTolerance = (approach.Start1Value - tolernace) * (approach.Start1Value - tolernace);
-                        start1 = distFromSurfaceSqr >= greaterThanTolerance && distFromSurfaceSqr <= lessThanTolerance;
-                        break;
-                    case Conditions.DistanceFromPositionC: // could save a sqrt by inlining and using heightDir
-
-                        if (desiredElevation > 0)
-                            start1 = MyUtils.GetPointLineDistance(ref elStartLineC, ref positionC, ref Position) - aConst.CollisionSize <= approach.Start1Value;
-                        else
-                            start1 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize <= approach.Start1Value;
-                        break;
-                    case Conditions.DistanceToPositionC: // could save a sqrt by inlining and using heightDir
-                        if (desiredElevation > 0)
-                            start1 = MyUtils.GetPointLineDistance(ref elStartLineC, ref positionC, ref Position) - aConst.CollisionSize >= approach.Start1Value;
-                        else
-                            start1 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize >= approach.Start1Value;
-                        break;
-                    case Conditions.DistanceFromPositionB: // could save a sqrt by inlining and using heightDir
-
-                        if (desiredElevation > 0)
-                            start1 = MyUtils.GetPointLineDistance(ref elStartLineB, ref positionB, ref Position) - aConst.CollisionSize <= approach.Start1Value;
-                        else
-                            start1 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize <= approach.Start1Value;
-                        break;
-                    case Conditions.DistanceToPositionB: // could save a sqrt by inlining and using heightDir
-                        if (desiredElevation > 0)
-                            start1 = MyUtils.GetPointLineDistance(ref elStartLineB, ref positionB, ref Position) - aConst.CollisionSize >= approach.Start1Value;
-                        else
-                            start1 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize >= approach.Start1Value;
-                        break;
-                    case Conditions.DistanceFromTarget:
-                        start1 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize <= approach.Start1Value;
-                        break;
-                    case Conditions.DistanceToTarget:
-                        start1 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize >= approach.Start1Value;
-                        break;
-                    case Conditions.DistanceFromEndTrajectory:
-                        start1 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize <= approach.Start1Value;
-                        break;
-                    case Conditions.DistanceToEndTrajectory:
-                        start1 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize >= approach.Start1Value;
-                        break;
-                    case Conditions.Lifetime:
-                        start1 = Info.RelativeAge >= approach.Start1Value;
-                        break;
-                    case Conditions.Deadtime:
-                        start1 = Info.RelativeAge <= approach.Start1Value;
-                        break;
-                    case Conditions.RelativeHealthLost:
-                        start1 = aInfo.StartHealth - Info.BaseHealthPool >= approach.Start1Value;
-                        break;
-                    case Conditions.HealthRemaining:
-                        start1 = Info.BaseHealthPool <= approach.Start1Value;
-                        break;
-                    case Conditions.RelativeLifetime:
-                        start1 = Info.RelativeAge - aInfo.RelativeAgeStart >= approach.Start1Value;
-                        break;
-                    case Conditions.RelativeDeadtime:
-                        start1 = Info.RelativeAge - aInfo.RelativeAgeStart <= approach.Start1Value;
-                        break;
-                    case Conditions.MinTravelRequired:
-                        start1 = Info.DistanceTraveled - aInfo.StartDistanceTraveled >= approach.Start1Value;
-                        break;
-                    case Conditions.MaxTravelRequired:
-                        start1 = Info.DistanceTraveled - aInfo.StartDistanceTraveled <= approach.Start1Value;
-                        break;
-                    case Conditions.Spawn:
-                    case Conditions.Ignore:
-                        start1 = true;
-                        break;
-                    case Conditions.NextTimedSpawn:
-                    case Conditions.SinceTimedSpawn:
-                        if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.Frags < aConst.MaxFrags)
-                        {
-                            var groupDelay = aConst.HasFragGroup && Info.Frags % aConst.FragGroupSize == 0;
-                            var notFragZero = Info.Frags != 0;
-                            var longestSpawnDelay = Math.Max(groupDelay ? aConst.FragGroupDelay : 0, notFragZero ? aConst.FragInterval : 0);
-
-                            timeSinceSpawn = Info.RelativeAge - Info.LastFragTime;
-                            nextSpawn = longestSpawnDelay - timeSinceSpawn;
-                            var trueCondition = approach.StartCon1 == Conditions.NextTimedSpawn ? nextSpawn <= approach.Start1Value : timeSinceSpawn >= approach.Start1Value;
-
-                            var timeSinceStart = aConst.FragStartTime - Info.RelativeAge;
-                            if (timeSinceStart >= 0)
-                            {
-                                if (timeSinceStart <= approach.Start1Value && trueCondition)
-                                    start1 = true;
-                            }
-                            else if (trueCondition)
-                                start1 = true;
-                        }
-                        else
-                            start1 = true;
-                        break;
-                    case Conditions.RelativeSpawns:
-                        start1 = Info.Frags - aInfo.RelativeSpawnsStart >= approach.Start1Value;
-                        break;
-                    case Conditions.EnemyTargetLoss:
-                        if (Info.Target.TargetObject == null)
-                            aInfo.TargetLossTime += Session.I.DeltaTimeRatio;
-                        else
-                            aInfo.TargetLossTime = 0;
-                        start1 = aInfo.TargetLossTime >= approach.Start1Value;
-                        break;
-                }
-
-                bool start2 = false;
-                switch (approach.StartCon2)
-                {
-                    case Conditions.DesiredElevation:
-                        var plane = new PlaneD(aInfo.PositionB, aInfo.OffsetUpDir);
-                        var distToPlane = approach.Elevation != RelativeTo.Surface ? Math.Abs(plane.DistanceToPoint(Position)) : plane.DistanceToPoint(Position);
-                        var tolernace = approach.ElevationTolerance + aConst.CollisionSize;
-                        var distFromSurfaceSqr = !Vector3D.IsZero(surfacePos) ? Vector3D.DistanceSquared(Position, surfacePos) : distToPlane * distToPlane;
-                        var lessThanTolerance = (approach.Start2Value + tolernace) * (approach.Start2Value + tolernace);
-                        var greaterThanTolerance = (approach.Start2Value - tolernace) * (approach.Start2Value - tolernace);
-                        start2 = distFromSurfaceSqr >= greaterThanTolerance && distFromSurfaceSqr <= lessThanTolerance;
-                        break;
-                    case Conditions.DistanceFromPositionC: // could save a sqrt by inlining and using heightDir
-                        if (desiredElevation > 0)
-                            start2 = MyUtils.GetPointLineDistance(ref elStartLineC, ref positionC, ref Position) - aConst.CollisionSize <= approach.Start2Value;
-                        else
-                            start2 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize <= approach.Start2Value;
-                        break;
-                    case Conditions.DistanceToPositionC: // could save a sqrt by inlining and using heightDir
-                        if (desiredElevation > 0)
-                            start2 = MyUtils.GetPointLineDistance(ref elStartLineC, ref positionC, ref Position) - aConst.CollisionSize >= approach.Start2Value;
-                        else
-                            start2 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize >= approach.Start2Value;
-                        break;
-                    case Conditions.DistanceFromPositionB: // could save a sqrt by inlining and using heightDir
-                        if (desiredElevation > 0)
-                            start2 = MyUtils.GetPointLineDistance(ref elStartLineB, ref positionB, ref Position) - aConst.CollisionSize <= approach.Start2Value;
-                        else
-                            start2 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize <= approach.Start2Value;
-                        break;
-                    case Conditions.DistanceToPositionB: // could save a sqrt by inlining and using heightDir
-                        if (desiredElevation > 0)
-                            start2 = MyUtils.GetPointLineDistance(ref elStartLineB, ref positionB, ref Position) - aConst.CollisionSize >= approach.Start2Value;
-                        else
-                            start2 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize >= approach.Start2Value;
-                        break;
-                    case Conditions.DistanceFromTarget:
-                        start2 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize <= approach.Start2Value;
-                        break;
-                    case Conditions.DistanceToTarget:
-                        start2 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize >= approach.Start2Value;
-                        break;
-                    case Conditions.DistanceFromEndTrajectory:
-                        start2 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize <= approach.Start2Value;
-                        break;
-                    case Conditions.DistanceToEndTrajectory:
-                        start2 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize >= approach.Start2Value;
-                        break;
-                    case Conditions.Lifetime:
-                        start2 = Info.RelativeAge >= approach.Start2Value;
-                        break;
-                    case Conditions.Deadtime:
-                        start2 = Info.RelativeAge <= approach.Start2Value;
-                        break;
-                    case Conditions.RelativeHealthLost:
-                        start2 = aInfo.StartHealth - Info.BaseHealthPool >= approach.Start2Value;
-                        break;
-                    case Conditions.HealthRemaining:
-                        start2 = Info.BaseHealthPool <= approach.Start2Value;
-                        break;
-                    case Conditions.RelativeLifetime:
-                        start2 = Info.RelativeAge - aInfo.RelativeAgeStart >= approach.Start2Value;
-                        break;
-                    case Conditions.RelativeDeadtime:
-                        start2 = Info.RelativeAge - aInfo.RelativeAgeStart <= approach.Start2Value;
-                        break;
-                    case Conditions.MinTravelRequired:
-                        start2 = Info.DistanceTraveled - aInfo.StartDistanceTraveled >= approach.Start2Value;
-                        break;
-                    case Conditions.MaxTravelRequired:
-                        start2 = Info.DistanceTraveled - aInfo.StartDistanceTraveled <= approach.Start2Value;
-                        break;
-                    case Conditions.Spawn:
-                    case Conditions.Ignore:
-                        start2 = true;
-                        break;
-                    case Conditions.NextTimedSpawn:
-                    case Conditions.SinceTimedSpawn:
-                        if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.Frags < aConst.MaxFrags)
-                        {
-                            var groupDelay = aConst.HasFragGroup && Info.Frags % aConst.FragGroupSize == 0;
-                            var notFragZero = Info.Frags != 0;
-                            var longestSpawnDelay = Math.Max(groupDelay ? aConst.FragGroupDelay : 0, notFragZero ? aConst.FragInterval : 0);
-
-                            timeSinceSpawn = Info.RelativeAge - Info.LastFragTime;
-                            nextSpawn = longestSpawnDelay - timeSinceSpawn;
-                            var trueCondition = approach.StartCon2 == Conditions.NextTimedSpawn ? nextSpawn <= approach.Start2Value : timeSinceSpawn >= approach.Start2Value;
-                            var timeSinceStart = aConst.FragStartTime - Info.RelativeAge;
-                            if (timeSinceStart >= 0)
-                            {
-                                if (timeSinceStart <= approach.Start2Value && trueCondition)
-                                    start2 = true;
-                            }
-                            else if (trueCondition)
-                                start2 = true;
-                        }
-                        else
-                            start2 = true;
-                        break;
-                    case Conditions.RelativeSpawns:
-                        start2 = Info.Frags - aInfo.RelativeSpawnsStart >= approach.Start2Value;
-                        break;
-                    case Conditions.EnemyTargetLoss:
-                        if (Info.Target.TargetObject == null)
-                            aInfo.TargetLossTime += Session.I.DeltaTimeRatio;
-                        else
-                            aInfo.TargetLossTime = 0;
-                        start2 = aInfo.TargetLossTime >= approach.Start2Value;
-                        break;
-                }
+                bool start1 = CheckApproachCondition(approach.StartCon1, approach.Start1Value, approach.StartAnd, ref targetPos, aConst, aInfo, approach, ref surfacePos, ref positionB, ref positionC, ref timeSinceSpawn, ref nextSpawn, ref elStartLineC, ref elStartLineB);
+                bool start2 = CheckApproachCondition(approach.StartCon2, approach.Start2Value, approach.StartAnd, ref targetPos, aConst, aInfo, approach, ref surfacePos, ref positionB, ref positionC, ref timeSinceSpawn, ref nextSpawn, ref elStartLineC, ref elStartLineB);
                 #endregion
 
                 #region Start
@@ -1463,13 +1250,13 @@ namespace CoreSystems.Projectiles
                 {
                     accelMpsMulti = aConst.AccelInMetersPerSec * approach.AccelMulti;
                     speedCapMulti = approach.SpeedCapMulti;
-                    
+
                     var fwdDestDir = approach.Forward == FwdRelativeTo.ForwardElevationDirection;
                     var upDestDir = approach.Up == UpRelativeTo.UpElevationDirection;
 
                     var fwdDir = !fwdDestDir ? aInfo.OffsetFwdDir : Vector3D.Normalize(!approach.ElevationRelatveToC ? positionC - positionB : positionB - positionC);
                     var upDir = !upDestDir ? aInfo.OffsetUpDir : fwdDestDir ? fwdDir : Vector3D.Normalize(!approach.ElevationRelatveToC ? positionC - positionB : positionB - positionC);
-                    
+
                     var surfaceRefPos = !approach.ElevationRelatveToC ? positionB : positionC;
 
                     #region Elevation Correction
@@ -1480,7 +1267,7 @@ namespace CoreSystems.Projectiles
                                 if (Info.MyPlanet != null && approach.Elevation == RelativeTo.Surface)
                                 {
                                     Vector3D followSurfacePos;
-                                    elOffset = PlanetSurfaceHeightAdjustment(surfaceRefPos - heightOffset,  out followSurfacePos);
+                                    elOffset = PlanetSurfaceHeightAdjustment(surfaceRefPos - heightOffset, out followSurfacePos);
                                 }
                                 else
                                     elOffset = heightOffset;
@@ -1561,7 +1348,7 @@ namespace CoreSystems.Projectiles
 
                     var desiredPos = !approach.TrajectoryRelativeToB ? positionC + elOffset : positionB + elOffset;
                     if (desiredPos == Position)
-                        desiredPos += (aInfo.OffsetFwdDir * 10000);
+                        desiredPos += aInfo.OffsetFwdDir * 10000;
 
                     TargetPosition = approach.Orbit ? ApproachOrbits(approach, desiredPos, accelMpsMulti, speedCapMulti) : desiredPos;
 
@@ -1572,354 +1359,153 @@ namespace CoreSystems.Projectiles
                 #endregion
 
                 #region End Conditions
-                bool end1 = false;
                 var endLineC = positionC + heightOffset;
-                var endLineB= positionB + heightOffset;
-                switch (approach.EndCon1)
-                {
-                    case Conditions.DesiredElevation:
-                        var plane = new PlaneD(aInfo.PositionB, aInfo.OffsetUpDir);
-                        var distToPlane = approach.Elevation != RelativeTo.Surface ? Math.Abs(plane.DistanceToPoint(Position)) : plane.DistanceToPoint(Position);
-                        var tolernace = approach.ElevationTolerance + aConst.CollisionSize;
-                        var distFromSurfaceSqr = !Vector3D.IsZero(surfacePos) ? Vector3D.DistanceSquared(Position, surfacePos) : distToPlane * distToPlane;
-                        var lessThanTolerance = (approach.End1Value + tolernace) * (approach.End1Value + tolernace);
-                        var greaterThanTolerance = (approach.End1Value - tolernace) * (approach.End1Value - tolernace);
-                        end1 = distFromSurfaceSqr >= greaterThanTolerance && distFromSurfaceSqr <= lessThanTolerance;
-                        break;
-                    case Conditions.DistanceFromPositionC:
-                        if (!MyUtils.IsZero(endLineC - positionC))
-                            end1 = MyUtils.GetPointLineDistance(ref endLineC, ref positionC, ref Position) - aConst.CollisionSize <= approach.End1Value;
-                        else
-                            end1 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize <= approach.End1Value;
-                        break;
-                    case Conditions.DistanceToPositionC:
-                        if (!MyUtils.IsZero(endLineC - positionC))
-                            end1 = MyUtils.GetPointLineDistance(ref endLineC, ref positionC, ref Position) - aConst.CollisionSize >= approach.End1Value;
-                        else
-                            end1 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize >= approach.End1Value;
-                        break;
-                    case Conditions.DistanceFromPositionB:
-                        if (!MyUtils.IsZero(endLineB - positionB))
-                            end1 = MyUtils.GetPointLineDistance(ref endLineB, ref positionB, ref Position) - aConst.CollisionSize <= approach.End1Value;
-                        else
-                            end1 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize <= approach.End1Value;
-                        break;
-                    case Conditions.DistanceToPositionB:
-                        if (!MyUtils.IsZero(endLineB - positionB))
-                            end1 = MyUtils.GetPointLineDistance(ref endLineB, ref positionB, ref Position) - aConst.CollisionSize >= approach.End1Value;
-                        else
-                            end1 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize >= approach.End1Value;
-                        break;
-                    case Conditions.DistanceFromTarget:
-                        end1 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize <= approach.End1Value;
-                        break;
-                    case Conditions.DistanceToTarget:
-                        end1 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize >= approach.End1Value;
-                        break;
-                    case Conditions.DistanceFromEndTrajectory:
-                        end1 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize <= approach.End1Value;
-                        break;
-                    case Conditions.DistanceToEndTrajectory:
-                        end1 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize >= approach.End1Value;
-                        break;
-                    case Conditions.Lifetime:
-                        end1 = Info.RelativeAge >= approach.End1Value;
-                        break;
-                    case Conditions.Deadtime:
-                        end1 = Info.RelativeAge <= approach.End1Value;
-                        break;
-                    case Conditions.RelativeHealthLost:
-                        end1 = aInfo.StartHealth - Info.BaseHealthPool >= approach.End1Value;
-                        break;
-                    case Conditions.HealthRemaining:
-                        end1 = Info.BaseHealthPool <= approach.End1Value;
-                        break;
-                    case Conditions.RelativeLifetime:
-                        end1 = Info.RelativeAge - aInfo.RelativeAgeStart >= approach.End1Value;
-                        break;
-                    case Conditions.RelativeDeadtime:
-                        end1 = Info.RelativeAge - aInfo.RelativeAgeStart <= approach.End1Value;
-                        break;
-                    case Conditions.MinTravelRequired:
-                        end1 = Info.DistanceTraveled - aInfo.StartDistanceTraveled >= approach.End1Value;
-                        break;
-                    case Conditions.MaxTravelRequired:
-                        end1 = Info.DistanceTraveled - aInfo.StartDistanceTraveled <= approach.End1Value;
-                        break;
-                    case Conditions.Ignore:
-                        end1 = true;
-                        break;
-                    case Conditions.NextTimedSpawn:
-                    case Conditions.SinceTimedSpawn:
-                        if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.Frags < aConst.MaxFrags)
-                        {
-                            var groupDelay = aConst.HasFragGroup && Info.Frags % aConst.FragGroupSize == 0;
-                            var notFragZero = Info.Frags != 0;
-                            var longestSpawnDelay = Math.Max(groupDelay ? aConst.FragGroupDelay : 0,
-                                notFragZero ? aConst.FragInterval : 0);
-
-                            timeSinceSpawn = Info.RelativeAge - Info.LastFragTime;
-                            nextSpawn = longestSpawnDelay - timeSinceSpawn;
-                            var trueCondition = approach.EndCon1 == Conditions.NextTimedSpawn ? nextSpawn <= approach.End1Value : timeSinceSpawn >= approach.End1Value;
-
-                            var timeSinceStart = aConst.FragStartTime - Info.RelativeAge;
-                            if (timeSinceStart >= 0)
-                            {
-                                if (timeSinceStart <= approach.End1Value && trueCondition)
-                                    end1 = true;
-                            }
-                            else if (trueCondition)
-                                end1 = true;
-                        }
-                        else
-                            end1 = true;
-
-                        break;
-                    case Conditions.RelativeSpawns:
-                        end1 = Info.Frags - aInfo.RelativeSpawnsStart >= approach.End1Value;
-                        break;
-                    case Conditions.EnemyTargetLoss:
-                        if (Info.Target.TargetObject == null)
-                            aInfo.TargetLossTime += Session.I.DeltaTimeRatio;
-                        else
-                            aInfo.TargetLossTime = 0;
-                        end1 = aInfo.TargetLossTime >= approach.End1Value;
-                        break;
-                }
-
-                bool end2 = false;
-                switch (approach.EndCon2)
-                {
-                    case Conditions.DesiredElevation:
-                        var plane = new PlaneD(aInfo.PositionB, aInfo.OffsetUpDir);
-                        var distToPlane = approach.Elevation != RelativeTo.Surface ? Math.Abs(plane.DistanceToPoint(Position)) : plane.DistanceToPoint(Position);
-                        var tolernace = approach.ElevationTolerance + aConst.CollisionSize;
-                        var distFromSurfaceSqr = !Vector3D.IsZero(surfacePos) ? Vector3D.DistanceSquared(Position, surfacePos) : distToPlane * distToPlane;
-                        var lessThanTolerance = (approach.End2Value + tolernace) * (approach.End2Value + tolernace);
-                        var greaterThanTolerance = (approach.End2Value - tolernace) * (approach.End2Value - tolernace);
-                        end2 = distFromSurfaceSqr >= greaterThanTolerance && distFromSurfaceSqr <= lessThanTolerance;
-                        break;
-                    case Conditions.DistanceFromPositionC:
-                        if (!MyUtils.IsZero(endLineC - positionC))
-                            end2 = MyUtils.GetPointLineDistance(ref endLineC, ref positionC, ref Position) - aConst.CollisionSize <= approach.End2Value;
-                        else
-                            end2 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize <= approach.End2Value;
-                        break;
-                    case Conditions.DistanceToPositionC:
-                        if (!MyUtils.IsZero(endLineC - positionC))
-                            end2 = MyUtils.GetPointLineDistance(ref endLineC, ref positionC, ref Position) - aConst.CollisionSize >= approach.End2Value;
-                        else
-                            end2 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize >= approach.End2Value;
-                        break;
-                    case Conditions.DistanceFromPositionB:
-                        if (!MyUtils.IsZero(endLineB - positionB))
-                            end2 = MyUtils.GetPointLineDistance(ref endLineB, ref positionB, ref Position) - aConst.CollisionSize <= approach.End2Value;
-                        else
-                            end2 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize <= approach.End2Value;
-                        break;
-                    case Conditions.DistanceToPositionB:
-                        if (!MyUtils.IsZero(endLineB - positionB))
-                            end2 = MyUtils.GetPointLineDistance(ref endLineB, ref positionB, ref Position) - aConst.CollisionSize >= approach.End2Value;
-                        else
-                            end2 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize >= approach.End2Value;
-                        break;
-                    case Conditions.DistanceFromTarget:
-                        end2 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize <= approach.End2Value;
-                        break;
-                    case Conditions.DistanceToTarget:
-                        end2 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize >= approach.End2Value;
-                        break;
-                    case Conditions.DistanceFromEndTrajectory:
-                        end2 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize <= approach.End2Value;
-                        break;
-                    case Conditions.DistanceToEndTrajectory:
-                        end2 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize >= approach.End2Value;
-                        break;
-                    case Conditions.Lifetime:
-                        end2 = Info.RelativeAge >= approach.End2Value;
-                        break;
-                    case Conditions.Deadtime:
-                        end2 = Info.RelativeAge <= approach.End2Value;
-                        break;
-                    case Conditions.RelativeHealthLost:
-                        end2 = aInfo.StartHealth - Info.BaseHealthPool >= approach.End2Value;
-                        break;
-                    case Conditions.HealthRemaining:
-                        end2 = Info.BaseHealthPool <= approach.End2Value;
-                        break;
-                    case Conditions.RelativeLifetime:
-                        end2 = Info.RelativeAge - aInfo.RelativeAgeStart >= approach.End2Value;
-                        break;
-                    case Conditions.RelativeDeadtime:
-                        end2 = Info.RelativeAge - aInfo.RelativeAgeStart <= approach.End2Value;
-                        break;
-                    case Conditions.MinTravelRequired:
-                        end2 = Info.DistanceTraveled - aInfo.StartDistanceTraveled >= approach.End2Value;
-                        break;
-                    case Conditions.MaxTravelRequired:
-                        end2 = Info.DistanceTraveled - aInfo.StartDistanceTraveled <= approach.End2Value;
-                        break;
-                    case Conditions.Ignore:
-                        end2 = true;
-                        break;
-                    case Conditions.NextTimedSpawn:
-                    case Conditions.SinceTimedSpawn:
-
-                        if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.Frags < aConst.MaxFrags)
-                        {
-                            var groupDelay = aConst.HasFragGroup && Info.Frags % aConst.FragGroupSize == 0;
-                            var notFragZero = Info.Frags != 0;
-                            var longestSpawnDelay = Math.Max(groupDelay ? aConst.FragGroupDelay : 0, notFragZero ? aConst.FragInterval : 0);
-
-                            timeSinceSpawn = Info.RelativeAge - Info.LastFragTime;
-                            nextSpawn = longestSpawnDelay - timeSinceSpawn;
-                            var trueCondition = approach.EndCon2 == Conditions.NextTimedSpawn ? nextSpawn <= approach.End2Value : timeSinceSpawn >= approach.End2Value;
-
-                            var timeSinceStart = aConst.FragStartTime - Info.RelativeAge;
-                            if (timeSinceStart >= 0)
-                            {
-                                if (timeSinceStart <= approach.End2Value && trueCondition)
-                                    end2 = true;
-                            }
-                            else if (trueCondition)
-                                end2 = true;
-                        }
-                        else
-                            end2 = true;
-                        break;
-                    case Conditions.RelativeSpawns:
-                        end2 = Info.Frags - aInfo.RelativeSpawnsStart >= approach.End2Value;
-                        break;
-                    case Conditions.EnemyTargetLoss:
-                        if (Info.Target.TargetObject == null)
-                            aInfo.TargetLossTime += Session.I.DeltaTimeRatio;
-                        else
-                            aInfo.TargetLossTime = 0;
-                        end2 = aInfo.TargetLossTime >= approach.End2Value;
-                        break;
-                }
-
-                bool end3 = false;
-                switch (approach.EndCon3)
-                {
-                    case Conditions.DesiredElevation:
-                        var plane = new PlaneD(aInfo.PositionB, aInfo.OffsetUpDir);
-                        var distToPlane = approach.Elevation != RelativeTo.Surface ? Math.Abs(plane.DistanceToPoint(Position)) : plane.DistanceToPoint(Position);
-                        var tolernace = approach.ElevationTolerance + aConst.CollisionSize;
-                        var distFromSurfaceSqr = !Vector3D.IsZero(surfacePos) ? Vector3D.DistanceSquared(Position, surfacePos) : distToPlane * distToPlane;
-                        var lessThanTolerance = (approach.End3Value + tolernace) * (approach.End3Value + tolernace);
-                        var greaterThanTolerance = (approach.End3Value - tolernace) * (approach.End3Value - tolernace);
-                        end3 = distFromSurfaceSqr >= greaterThanTolerance && distFromSurfaceSqr <= lessThanTolerance;
-                        break;
-                    case Conditions.DistanceFromPositionC:
-                        if (!MyUtils.IsZero(endLineC - positionC))
-                            end3 = MyUtils.GetPointLineDistance(ref endLineC, ref positionC, ref Position) - aConst.CollisionSize <= approach.End2Value;
-                        else
-                            end3 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize <= approach.End3Value;
-                        break;
-                    case Conditions.DistanceToPositionC:
-                        if (!MyUtils.IsZero(endLineC - positionC))
-                            end3 = MyUtils.GetPointLineDistance(ref endLineC, ref positionC, ref Position) - aConst.CollisionSize >= approach.End2Value;
-                        else
-                            end3 = Vector3D.Distance(positionC, Position) - aConst.CollisionSize >= approach.End3Value;
-                        break;
-                    case Conditions.DistanceFromPositionB:
-                        if (!MyUtils.IsZero(endLineB - positionB))
-                            end3 = MyUtils.GetPointLineDistance(ref endLineB, ref positionB, ref Position) - aConst.CollisionSize <= approach.End2Value;
-                        else
-                            end3 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize <= approach.End3Value;
-                        break;
-                    case Conditions.DistanceToPositionB:
-                        if (!MyUtils.IsZero(endLineB - positionB))
-                            end3 = MyUtils.GetPointLineDistance(ref endLineB, ref positionB, ref Position) - aConst.CollisionSize >= approach.End2Value;
-                        else
-                            end3 = Vector3D.Distance(positionB, Position) - aConst.CollisionSize >= approach.End3Value;
-                        break;
-                    case Conditions.DistanceFromTarget:
-                            end3 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize <= approach.End3Value;
-                        break;
-                    case Conditions.DistanceToTarget:
-                            end3 = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize >= approach.End3Value;
-                        break;
-                    case Conditions.DistanceFromEndTrajectory:
-                        end3 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize <= approach.End3Value;
-                        break;
-                    case Conditions.DistanceToEndTrajectory:
-                        end3 = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize >= approach.End3Value;
-                        break;
-                    case Conditions.Lifetime:
-                        end3 = Info.RelativeAge >= approach.End3Value;
-                        break;
-                    case Conditions.Deadtime:
-                        end3 = Info.RelativeAge <= approach.End3Value;
-                        break;
-                    case Conditions.RelativeHealthLost:
-                        end3 = aInfo.StartHealth - Info.BaseHealthPool >= approach.End3Value;
-                        break;
-                    case Conditions.HealthRemaining:
-                        end3 = Info.BaseHealthPool <= approach.End3Value;
-                        break;
-                    case Conditions.RelativeLifetime:
-                        end3 = Info.RelativeAge - aInfo.RelativeAgeStart >= approach.End3Value;
-                        break;
-                    case Conditions.RelativeDeadtime:
-                        end3 = Info.RelativeAge - aInfo.RelativeAgeStart <= approach.End3Value;
-                        break;
-                    case Conditions.MinTravelRequired:
-                        end3 = Info.DistanceTraveled - aInfo.StartDistanceTraveled >= approach.End3Value;
-                        break;
-                    case Conditions.MaxTravelRequired:
-                        end3 = Info.DistanceTraveled - aInfo.StartDistanceTraveled <= approach.End3Value;
-                        break;
-                    case Conditions.Ignore:
-                        end3 = true;
-                        break;
-                    case Conditions.NextTimedSpawn:
-                    case Conditions.SinceTimedSpawn:
-
-                        if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.Frags < aConst.MaxFrags)
-                        {
-                            var groupDelay = aConst.HasFragGroup && Info.Frags % aConst.FragGroupSize == 0;
-                            var notFragZero = Info.Frags != 0;
-                            var longestSpawnDelay = Math.Max(groupDelay ? aConst.FragGroupDelay : 0, notFragZero ? aConst.FragInterval : 0);
-
-                            timeSinceSpawn = Info.RelativeAge - Info.LastFragTime;
-                            nextSpawn = longestSpawnDelay - timeSinceSpawn;
-                            var trueCondition = approach.EndCon3 == Conditions.NextTimedSpawn ? nextSpawn <= approach.End3Value : timeSinceSpawn >= approach.End3Value;
-
-                            var timeSinceStart = aConst.FragStartTime - Info.RelativeAge;
-                            if (timeSinceStart >= 0)
-                            {
-                                if (timeSinceStart <= approach.End3Value && trueCondition)
-                                    end3 = true;
-                            }
-                            else if (trueCondition)
-                                end3 = true;
-                        }
-                        else
-                            end3 = true;
-                        break;
-                    case Conditions.RelativeSpawns:
-                        end3 = Info.Frags - aInfo.RelativeSpawnsStart >= approach.End3Value;
-                        break;
-                    case Conditions.EnemyTargetLoss:
-                        if (Info.Target.TargetObject == null)
-                            aInfo.TargetLossTime += Session.I.DeltaTimeRatio;
-                        else
-                            aInfo.TargetLossTime = 0;
-                        end3 = aInfo.TargetLossTime >= approach.End3Value;
-                        break;
-                }
-
+                var endLineB = positionB + heightOffset;
+                bool end1 = CheckApproachCondition(approach.EndCon1, approach.End1Value, approach.EndAnd, ref targetPos, aConst, aInfo, approach, ref surfacePos, ref positionB, ref positionC, ref timeSinceSpawn, ref nextSpawn, ref endLineC, ref endLineB);
+                bool end2 = CheckApproachCondition(approach.EndCon2, approach.End2Value, approach.EndAnd, ref targetPos, aConst, aInfo, approach, ref surfacePos, ref positionB, ref positionC, ref timeSinceSpawn, ref nextSpawn, ref endLineC, ref endLineB);
+                bool end3 = CheckApproachCondition(approach.EndCon3, approach.End3Value, approach.EndAnd, ref targetPos, aConst, aInfo, approach, ref surfacePos, ref positionB, ref positionC, ref timeSinceSpawn, ref nextSpawn, ref endLineC, ref endLineB);
+                bool end4 = CheckApproachCondition(approach.EndCon4, approach.End4Value, approach.EndAnd, ref targetPos, aConst, aInfo, approach, ref surfacePos, ref positionB, ref positionC, ref timeSinceSpawn, ref nextSpawn, ref endLineC, ref endLineB);
+                bool end5 = CheckApproachCondition(approach.EndCon5, approach.End5Value, approach.EndAnd, ref targetPos, aConst, aInfo, approach, ref surfacePos, ref positionB, ref positionC, ref timeSinceSpawn, ref nextSpawn, ref endLineC, ref endLineB);
                 #endregion
 
-                if (approach.EndAnd && end1 && end2 || !approach.EndAnd && (end1 || end2))
-                    ApproachEnd(approach, end1, end2, end3, ref positionB, ref positionC, ref targetPos);
+                if (approach.EndAnd && end1 && end2 && end3 && end4 && end5 || !approach.EndAnd && (end1 || end2 || end3 || end4 || end5))
+                    ApproachEnd(approach, end1, end2, end3, end4, end5, ref positionB, ref positionC, ref targetPos);
 
                 if (s.DebugMod && s.HandlesInput)
-                    ApproachDebug(approach, ref positionC, ref positionB, ref elOffset, ref heightOffset, ref targetPos, start1, start2, end1, end2, end3, nextSpawn, timeSinceSpawn, stageChange);
-
+                    ApproachDebug(approach, ref positionC, ref positionB, ref elOffset, ref heightOffset, ref targetPos, start1, start2, end1, end2, end3, end4, end5, nextSpawn, timeSinceSpawn, stageChange);
             }
+        }
+
+        // this does NOT need to be inlined and there was a ton of errors with the copied end3 already
+        private bool CheckApproachCondition(Conditions con, double conVal, bool conditionAnd, ref Vector3D targetPos, AmmoConstants aConst, ApproachInfo aInfo, ApproachConstants appConst, ref Vector3D surfacePos, ref Vector3D positionB, ref Vector3D positionC, ref double timeSinceSpawn, ref double nextSpawn, ref Vector3D lineC, ref Vector3D lineB)
+        {
+            bool condition = false;
+            switch (con)
+            {
+                case Conditions.Spawn:
+                case Conditions.Ignore:
+                    condition = conditionAnd; // if and, return true so it doesn't block real condition, if or return false so it doesn't false positive
+                    break;
+                case Conditions.DesiredElevation:
+                    var plane = new PlaneD(aInfo.PositionB, aInfo.OffsetUpDir);
+                    var distToPlane = appConst.Elevation != RelativeTo.Surface ? Math.Abs(plane.DistanceToPoint(Position)) : plane.DistanceToPoint(Position);
+                    var tolernace = appConst.ElevationTolerance + aConst.CollisionSize;
+                    var distFromSurfaceSqr = !Vector3D.IsZero(surfacePos) ? Vector3D.DistanceSquared(Position, surfacePos) : distToPlane * distToPlane;
+                    var lessThanTolerance = (conVal + tolernace) * (conVal + tolernace);
+                    var greaterThanTolerance = (conVal - tolernace) * (conVal - tolernace);
+                    condition = distFromSurfaceSqr >= greaterThanTolerance && distFromSurfaceSqr <= lessThanTolerance;
+                    break;
+                case Conditions.DistanceFromPositionC:
+                    if (!MyUtils.IsZero(lineC - positionC))
+                        condition = MyUtils.GetPointLineDistance(ref lineC, ref positionC, ref Position) - aConst.CollisionSize <= conVal;
+                    else
+                        condition = Vector3D.Distance(positionC, Position) - aConst.CollisionSize <= conVal;
+                    break;
+                case Conditions.DistanceToPositionC:
+                    if (!MyUtils.IsZero(lineC - positionC))
+                        condition = MyUtils.GetPointLineDistance(ref lineC, ref positionC, ref Position) - aConst.CollisionSize >= conVal;
+                    else
+                        condition = Vector3D.Distance(positionC, Position) - aConst.CollisionSize >= conVal;
+                    break;
+                case Conditions.DistanceFromPositionB:
+                    if (!MyUtils.IsZero(lineB - positionB))
+                        condition = MyUtils.GetPointLineDistance(ref lineB, ref positionB, ref Position) - aConst.CollisionSize <= conVal;
+                    else
+                        condition = Vector3D.Distance(positionB, Position) - aConst.CollisionSize <= conVal;
+                    break;
+                case Conditions.DistanceToPositionB:
+                    if (!MyUtils.IsZero(lineB - positionB))
+                        condition = MyUtils.GetPointLineDistance(ref lineB, ref positionB, ref Position) - aConst.CollisionSize >= conVal;
+                    else
+                        condition = Vector3D.Distance(positionB, Position) - aConst.CollisionSize >= conVal;
+                    break;
+                case Conditions.DistanceFromTarget:
+                    condition = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize <= conVal;
+                    break;
+                case Conditions.DistanceToTarget:
+                    condition = Vector3D.Distance(targetPos, Position) - aConst.CollisionSize >= conVal;
+                    break;
+                case Conditions.DistanceFromEndTrajectory:
+                    condition = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize <= conVal;
+                    break;
+                case Conditions.DistanceToEndTrajectory:
+                    condition = Vector3D.Distance(TargetPosition, Position) - aConst.CollisionSize >= conVal;
+                    break;
+                case Conditions.Lifetime:
+                    condition = Info.RelativeAge >= conVal;
+                    break;
+                case Conditions.Deadtime:
+                    condition = Info.RelativeAge <= conVal;
+                    break;
+                case Conditions.RelativeHealthLost:
+                    condition = aInfo.StartHealth - Info.BaseHealthPool >= conVal;
+                    break;
+                case Conditions.HealthRemaining:
+                    condition = Info.BaseHealthPool <= conVal;
+                    break;
+                case Conditions.RelativeLifetime:
+                    condition = Info.RelativeAge - aInfo.RelativeAgeStart >= conVal;
+                    break;
+                case Conditions.RelativeDeadtime:
+                    condition = Info.RelativeAge - aInfo.RelativeAgeStart <= conVal;
+                    break;
+                case Conditions.MinTravelRequired:
+                    condition = Info.DistanceTraveled - aInfo.StartDistanceTraveled >= conVal;
+                    break;
+                case Conditions.MaxTravelRequired:
+                    condition = Info.DistanceTraveled - aInfo.StartDistanceTraveled <= conVal;
+                    break;
+                case Conditions.NextTimedSpawn:
+                case Conditions.SinceTimedSpawn:
+                    if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.Frags < aConst.MaxFrags)
+                    {
+                        var groupDelay = aConst.HasFragGroup && Info.Frags % aConst.FragGroupSize == 0;
+                        var notFragZero = Info.Frags != 0;
+                        var longestSpawnDelay = Math.Max(groupDelay ? aConst.FragGroupDelay : 0,
+                            notFragZero ? aConst.FragInterval : 0);
+
+                        timeSinceSpawn = Info.RelativeAge - Info.LastFragTime;
+                        nextSpawn = longestSpawnDelay - timeSinceSpawn;
+                        var trueCondition = con == Conditions.NextTimedSpawn ? nextSpawn <= conVal : timeSinceSpawn >= conVal;
+
+                        var timeSinceStart = aConst.FragStartTime - Info.RelativeAge;
+                        if (timeSinceStart >= 0)
+                        {
+                            if (timeSinceStart <= conVal && trueCondition)
+                                condition = true;
+                        }
+                        else if (trueCondition)
+                            condition = true;
+                    }
+                    else
+                        condition = true;
+
+                    break;
+                case Conditions.RelativeSpawns:
+                    condition = Info.Frags - aInfo.RelativeSpawnsStart >= conVal;
+                    break;
+                case Conditions.EnemyTargetLoss:
+                    if (Info.Target.TargetObject == null)
+                        aInfo.TargetLossTime += Session.I.DeltaTimeRatio;
+                    else
+                        aInfo.TargetLossTime = 0;
+                    condition = aInfo.TargetLossTime >= conVal;
+                    break;
+                case Conditions.ReaquiredTarget:
+                    if (Info.Target.TargetObject == null)
+                        aInfo.TargetLossTime += Session.I.DeltaTimeRatio;
+                    else
+                        aInfo.TargetLossTime = 0;
+                    condition = aInfo.TargetLossTime <= conVal;
+                    break;
+                case Conditions.EnemySeekersGreaterThanEqualTo:
+                    condition = Seekers.Count >= conVal;
+                    break;
+                case Conditions.EnemySeekersLessThanEqualTo:
+                    condition = Seekers.Count <= conVal;
+                    break;
+            }
+            return condition;
         }
 
         private void ApproachStartEvent(ApproachConstants approach, ref Vector3D positionB, ref Vector3D positionC, ref Vector3D targetPos)
@@ -1976,10 +1562,13 @@ namespace CoreSystems.Projectiles
                             break;
                     }
                     break;
+                case StageEvents.ForceRetarget:
+                    NewTarget();
+                    break;
             }
         }
 
-        private void ApproachEnd(ApproachConstants approach, bool end1, bool end2, bool end3, ref Vector3D positionB, ref Vector3D positionC, ref Vector3D targetPos)
+        private void ApproachEnd(ApproachConstants approach, bool end1, bool end2, bool end3, bool end4, bool end5, ref Vector3D positionB, ref Vector3D positionC, ref Vector3D targetPos)
         {
             var aConst = Info.AmmoDef.Const;
             var storage = Info.Storage;
@@ -2042,6 +1631,12 @@ namespace CoreSystems.Projectiles
                 if (Session.I.IsServer && Info.Weapon.Reload.LifetimeLoads > 0 && def.ReloadRefund)
                     --Info.Weapon.Reload.LifetimeLoads;
             }
+            else if (endEvent == StageEvents.ForceRetarget)
+            {
+                NewTarget();
+                
+                
+            }
 
             if (moveForward)
             {
@@ -2054,7 +1649,7 @@ namespace CoreSystems.Projectiles
                 ++storage.ApproachInfo.Storage[storage.RequestedStage].RunCount;
                 storage.LastActivatedStage = storage.RequestedStage;
                 var prev = storage.RequestedStage;
-                storage.RequestedStage = def.RestartCondition == ReInitCondition.MoveToPrevious ? prev : approach.GetRestartId(Info, end1, end2, end3);
+                storage.RequestedStage = def.RestartCondition == ReInitCondition.MoveToPrevious ? prev : approach.GetRestartId(Info, end1, end2, end3, end4, end5);
             }
             else if (!hasNextStep)
             {
@@ -2118,7 +1713,7 @@ namespace CoreSystems.Projectiles
             return surfacePos - checkPosition;
         }
 
-        private void ApproachDebug(ApproachConstants approach, ref Vector3D positionC, ref Vector3D positionB, ref Vector3D elOffset, ref Vector3D heightOffset, ref Vector3D targetPos, bool start1, bool start2, bool end1, bool end2, bool end3, double nextSpawn, double timeSinceSpawn, bool stageChange)
+        private void ApproachDebug(ApproachConstants approach, ref Vector3D positionC, ref Vector3D positionB, ref Vector3D elOffset, ref Vector3D heightOffset, ref Vector3D targetPos, bool start1, bool start2, bool end1, bool end2, bool end3, bool end4, bool end5, double nextSpawn, double timeSinceSpawn, bool stageChange)
         {
             var s = Session.I;
             var storage = Info.Storage;
@@ -2162,6 +1757,8 @@ namespace CoreSystems.Projectiles
                     End1 = end1,
                     End2 = end2,
                     End3 = end3,
+                    End4 = end4,
+                    End5 = end5,
                     ProId = Info.Id,
                     Stage = storage.LastActivatedStage,
                     TimeSinceSpawn = timeSinceSpawn,
@@ -3538,7 +3135,12 @@ namespace CoreSystems.Projectiles
                                     Info.EwarActive = true;
                                     netted.Info.Target.TargetObject = this;
                                     netted.Info.Target.TargetState = Target.TargetStates.IsProjectile;
+
                                     Seekers.Add(netted);
+                                    if (netted.Info.AmmoDef.Health > 0 && Info.AmmoDef.Const.GridsTargetSeekersTargetingThis)
+                                    {
+                                        s.Projectiles.AddProjectileTargets(netted);
+                                    }
                                 }
                             }
                         }
@@ -3572,6 +3174,10 @@ namespace CoreSystems.Projectiles
                                         netted.Info.Target.TargetObject = this;
                                         netted.Info.Target.TargetState = Target.TargetStates.IsProjectile;
                                         Seekers.Add(netted);
+                                        if (Info.AmmoDef.Const.GridsTargetSeekersTargetingThis)
+                                        {
+                                            s2.Projectiles.AddProjectileTargets(netted);
+                                        }
                                     }
                                 }
                             }
@@ -3747,6 +3353,12 @@ namespace CoreSystems.Projectiles
                 var shrapnel = projectiles.ShrapnelPool.Count > 0 ? projectiles.ShrapnelPool.Pop() : new Fragments();
                 shrapnel.Init(this, projectiles.FragmentPool, fragAmmoDef, ref newOrigin, ref pointDir);
                 projectiles.ShrapnelToSpawn.Add(shrapnel);
+            }
+
+            // why is this necessary
+            if (timedSpawn && aConst.GridsTargetSeekersTargetingThis)
+            {
+                Session.I.Projectiles.AddTargets.Add(this);
             }
 
             if (!spawn)

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileGen.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileGen.cs
@@ -1,5 +1,6 @@
 ﻿using CoreSystems.Support;
 using Sandbox.Game.Entities;
+using Sandbox.ModAPI;
 using VRage.Game.Entity;
 using VRageMath;
 using static CoreSystems.Support.NewProjectile;
@@ -33,7 +34,7 @@ namespace CoreSystems.Projectiles
                 var p = Session.I.Projectiles.ProjectilePool.Count > 0 ? Session.I.Projectiles.ProjectilePool.Pop() : new Projectile();
                 var info = p.Info;
                 var storage = info.Storage;
-                var target = info.Target;
+                var target = info.Target;  
             
                 info.Id = Session.I.Projectiles.CurrentProjectileId++;
                 info.Weapon = w;
@@ -266,7 +267,7 @@ namespace CoreSystems.Projectiles
                 var p = reAdd ?? AddTargets[i];
                 var info = p.Info;
                 var ai = info.Ai;
-                var target = info.Target;
+                var ptarget = info.Target;
                 var ammoDef = info.AmmoDef;
 
                 for (int t = 0; t < ai.TargetAis.Count; t++)
@@ -282,13 +283,13 @@ namespace CoreSystems.Projectiles
 
                         var dumbAdd = false;
 
-                        var notSmart = ammoDef.Trajectory.Guidance == TrajectoryDef.GuidanceType.None || p.Info.TestModeShot && p.HadTarget == Projectile.HadTargetState.None || info.Weapon.Comp.TypeSpecific == CoreComponent.CompTypeSpecific.Rifle && p.HadTarget == Projectile.HadTargetState.None;
+                        var notSmart = ammoDef.Trajectory.Guidance == TrajectoryDef.GuidanceType.None || info.TestModeShot && p.HadTarget == Projectile.HadTargetState.None || info.Weapon.Comp.TypeSpecific == CoreComponent.CompTypeSpecific.Rifle && p.HadTarget == Projectile.HadTargetState.None;
                         if (notSmart)
                         {
                             if (Vector3.Dot((Vector3)p.Direction, (Vector3)(info.Origin - targetAi.TopEntity.PositionComp.WorldMatrixRef.Translation)) < 0)
                             {
                                 var testRay = new RayD(info.Origin, p.Direction);
-                                var quickCheck = Vector3D.IsZero(targetAi.TopEntityVel, 0.025) && targetSphere.Intersects(testRay) != null || p.Info.TestModeShot;
+                                var quickCheck = Vector3D.IsZero(targetAi.TopEntityVel, 0.025) && targetSphere.Intersects(testRay) != null || info.TestModeShot;
 
                                 if (!quickCheck)
                                 {
@@ -304,10 +305,10 @@ namespace CoreSystems.Projectiles
                             }
                         }
 
-                        var cubeTarget = target.TargetObject as MyCubeBlock;
+                        var cubeTarget = ptarget.TargetObject as MyCubeBlock;
 
                         // Targeting grid center or painter of the currently checked grid
-                        var condition1 = cubeTarget == null && targetAi.TopEntity.EntityId == target.TopEntityId;
+                        var condition1 = cubeTarget == null && targetAi.TopEntity.EntityId == ptarget.TopEntityId;
 
                         // Targeting a cube on the grid being checked
                         var condition2 = targetAi.AiType == Ai.AiTypes.Grid && cubeTarget != null && targetAi.GridEntity.IsSameConstructAs(cubeTarget.CubeGrid);
@@ -317,15 +318,19 @@ namespace CoreSystems.Projectiles
                         var condition3 = !condition1 && !condition2 && cubeTarget != null && !notSmart && targetSphere.Contains(cubeTarget.CubeGrid.PositionComp.WorldVolume) != ContainmentType.Disjoint && !targetAi.Targets.TryGetValue(cubeTarget.CubeGrid, out tInfo);
                         
                         // Manual only
-                        var condition4 = target.TargetState == Target.TargetStates.IsFake && target.TopEntityId == 0;
+                        var condition4 = ptarget.TargetState == Target.TargetStates.IsFake && ptarget.TopEntityId == 0;
 
                         // ScanRange limitation, appears to be non functional
                         //var condition5 = !notSmart && ammoDef.Const.ScanRange > 0 && targetSphereReal.Contains(new BoundingSphereD(p.Position, ammoDef.Const.ScanRange)) != ContainmentType.Disjoint;
 
                         // TargetGridCenter only for subgrids/support, position within grid center + MaxTargetingRange of the grid being checked
-                        var condition6 = !notSmart && target.TargetObject is MyCubeGrid && targetSphere.Contains(target.TargetPos) == ContainmentType.Contains;
+                        var condition6 = !notSmart && ptarget.TargetObject is MyCubeGrid && targetSphere.Contains(ptarget.TargetPos) == ContainmentType.Contains;
 
-                        var validAi = !notSmart && (condition1 || condition2 || condition3 || condition4 || condition6);
+                        // Projectile is targeting a projectile that wants any targets it has to be added
+                        var condition7 = !condition1 && !condition2 && !condition3 && !condition4 && !condition6 && !notSmart && ptarget.TargetObject != null && ptarget.TargetState == Target.TargetStates.IsProjectile // why is HasTarget false when it has targets???
+                            && (((Projectile)ptarget.TargetObject)?.Info.AmmoDef.Const.GridsTargetSeekersTargetingThis ?? false) && targetSphere.Contains(ptarget.TargetPos) == ContainmentType.Contains;
+
+                        var validAi = !notSmart && (condition1 || condition2 || condition3 || condition4 || condition6 || condition7);
 
                         if (dumbAdd || validAi)
                         {

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileGen.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileGen.cs
@@ -328,7 +328,7 @@ namespace CoreSystems.Projectiles
 
                         // Projectile is targeting a projectile that wants any targets it has to be added
                         var condition7 = !condition1 && !condition2 && !condition3 && !condition4 && !condition6 && !notSmart && ptarget.TargetObject != null && ptarget.TargetState == Target.TargetStates.IsProjectile // why is HasTarget false when it has targets???
-                            && (((Projectile)ptarget.TargetObject)?.Info.AmmoDef.Const.GridsTargetSeekersTargetingThis ?? false) && targetSphere.Contains(ptarget.TargetPos) == ContainmentType.Contains;
+                            && (((Projectile)ptarget.TargetObject)?.Info?.AmmoDef.Const.GridsTargetSeekersTargetingThis ?? false) && targetSphere.Contains(ptarget.TargetPos) == ContainmentType.Contains;
 
                         var validAi = !notSmart && (condition1 || condition2 || condition3 || condition4 || condition6 || condition7);
 

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
@@ -747,6 +747,8 @@ namespace CoreSystems.Support
         public bool End1;
         public bool End2;
         public bool End3;
+        public bool End4;
+        public bool End5;
         public double TimeSinceSpawn;
         public double NextSpawn;
     }

--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -208,14 +208,14 @@ namespace CoreSystems
                 {
                     if (ApproachDebug.TimeSinceSpawn <= double.MinValue)
                     {
-                        ShowLocalNotify($"[Approach] Stage:{ApproachDebug.Stage} - Start1:{ApproachDebug.Approach.Definition.StartCondition1}:{ApproachDebug.Start1} - Start2:{ApproachDebug.Approach.Definition.StartCondition2}:{ApproachDebug.Start2} - End1:{ApproachDebug.Approach.Definition.EndCondition1}:{ApproachDebug.End1} - End2:{ApproachDebug.Approach.Definition.EndCondition2}:{ApproachDebug.End2} - End3:{ApproachDebug.Approach.Definition.EndCondition3}:{ApproachDebug.End3}", 160, "White");
+                        ShowLocalNotify($"[Approach] Stage:{ApproachDebug.Stage} - Start1:{ApproachDebug.Approach.Definition.StartCondition1}:{ApproachDebug.Start1} - Start2:{ApproachDebug.Approach.Definition.StartCondition2}:{ApproachDebug.Start2} - End1:{ApproachDebug.Approach.Definition.EndCondition1}:{ApproachDebug.End1} - End2:{ApproachDebug.Approach.Definition.EndCondition2}:{ApproachDebug.End2} - End3:{ApproachDebug.Approach.Definition.EndCondition3}:{ApproachDebug.End3}\n - End4:{ApproachDebug.Approach.Definition.EndCondition4}:{ApproachDebug.End4} - End5:{ApproachDebug.Approach.Definition.EndCondition5}:{ApproachDebug.End5}", 160, "White");
                         ShowLocalNotify($"[AccelMulti:{ApproachDebug.Approach.Definition.AccelMulti} - SpeedCapMulti:{ApproachDebug.Approach.Definition.SpeedCapMulti} - LeadDist:{ApproachDebug.Approach.Definition.LeadDistance} - RestartType:{ApproachDebug.Approach.Definition.RestartCondition}]", 160, "White");
                         ShowLocalNotify($"[Forward:{ApproachDebug.Approach.Forward} - Up:{ApproachDebug.Approach.Up} - Source:{ApproachDebug.Approach.PositionB} Destination:{ApproachDebug.Approach.PositionC}", 160, "White");
 
                     }
                     else
                     {
-                        ShowLocalNotify($"[Approach] Stage:{ApproachDebug.Stage} - Start1:{ApproachDebug.Approach.Definition.StartCondition1}:{ApproachDebug.Start1} - Start2:{ApproachDebug.Approach.Definition.StartCondition2}:{ApproachDebug.Start2} - End1:{ApproachDebug.Approach.Definition.EndCondition1}:{ApproachDebug.End1} - End2:{ApproachDebug.Approach.Definition.EndCondition2}:{ApproachDebug.End2} - End3:{ApproachDebug.Approach.Definition.EndCondition3}:{ApproachDebug.End3}", 160, "White");
+                        ShowLocalNotify($"[Approach] Stage:{ApproachDebug.Stage} - Start1:{ApproachDebug.Approach.Definition.StartCondition1}:{ApproachDebug.Start1} - Start2:{ApproachDebug.Approach.Definition.StartCondition2}:{ApproachDebug.Start2} - End1:{ApproachDebug.Approach.Definition.EndCondition1}:{ApproachDebug.End1} - End2:{ApproachDebug.Approach.Definition.EndCondition2}:{ApproachDebug.End2} - End3:{ApproachDebug.Approach.Definition.EndCondition3}:{ApproachDebug.End3}\n - End4:{ApproachDebug.Approach.Definition.EndCondition4}:{ApproachDebug.End4} - End5:{ApproachDebug.Approach.Definition.EndCondition5}:{ApproachDebug.End5}", 160, "White");
                         ShowLocalNotify($"[AccelMulti:{ApproachDebug.Approach.Definition.AccelMulti} - SpeedCapMulti:{ApproachDebug.Approach.Definition.SpeedCapMulti} - LeadDist:{ApproachDebug.Approach.Definition.LeadDistance} - RestartType:{ApproachDebug.Approach.Definition.RestartCondition}", 160, "White");
                         ShowLocalNotify($"[Forward:{ApproachDebug.Approach.Forward} - Up:{ApproachDebug.Approach.Up} - Source:{ApproachDebug.Approach.PositionB} Destination:{ApproachDebug.Approach.PositionC}", 160, "White");
                         ShowLocalNotify($"[TimeSinceSpawn:{ApproachDebug.TimeSinceSpawn} - NextSpawn:{ApproachDebug.NextSpawn}", 160, "White");
@@ -226,9 +226,9 @@ namespace CoreSystems
             else if (ApproachDebug.LastTick == Tick - 1 && Tick != 1)
             {
                 if (ApproachDebug.TimeSinceSpawn <= double.MinValue)
-                    ShowLocalNotify($"[Approach] Completed on stage:{ApproachDebug.Stage} - {ApproachDebug.Start1}:{ApproachDebug.Start2}:{ApproachDebug.End1}:{ApproachDebug.End2}", 2000, "White");
+                    ShowLocalNotify($"[Approach] Completed on stage:{ApproachDebug.Stage} - {ApproachDebug.Start1}:{ApproachDebug.Start2}:{ApproachDebug.End1}:{ApproachDebug.End2}:{ApproachDebug.End3}:{ApproachDebug.End4}:{ApproachDebug.End5}", 2000, "White");
                 else
-                    ShowLocalNotify($"[Approach] Completed on stage:{ApproachDebug.Stage} - {ApproachDebug.Start1}:{ApproachDebug.Start2}:{ApproachDebug.End1}:{ApproachDebug.End2} - {ApproachDebug.TimeSinceSpawn}:{ApproachDebug.NextSpawn}", 2000, "White");
+                    ShowLocalNotify($"[Approach] Completed on stage:{ApproachDebug.Stage} - {ApproachDebug.Start1}:{ApproachDebug.Start2}:{ApproachDebug.End1}:{ApproachDebug.End2}:{ApproachDebug.End3}:{ApproachDebug.End4}:{ApproachDebug.End5} - {ApproachDebug.TimeSinceSpawn}:{ApproachDebug.NextSpawn}", 2000, "White");
             }
 
             if (PersistentDebugDraws.Count > 0)

--- a/Data/Scripts/CoreSystems/Session/SessionUpdate.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionUpdate.cs
@@ -795,7 +795,8 @@ namespace CoreSystems
                         var shootRequest = (anyShot || finish);
 
                         var shotReady = canShoot && shootRequest;
-                        var shoot = shotReady && ai.CanShoot && (!aConst.RequiresTarget || w.Target.HasTarget || finish || overRide || wComp.ShootManager.Signal == Weapon.ShootManager.Signals.Manual);
+                        var noFireTarget = w.System.Values.HardPoint.Other.AllowNoTargetFiring;
+                        var shoot = shotReady && ai.CanShoot && (!aConst.RequiresTarget || w.Target.HasTarget || finish || overRide || noFireTarget || wComp.ShootManager.Signal == Weapon.ShootManager.Signals.Manual);
 
                         if (shoot) {
                             if (w.System.DelayCeaseFire && (autoShot || w.FinishShots))

--- a/Data/Scripts/CoreSystems/Support/Log.cs
+++ b/Data/Scripts/CoreSystems/Support/Log.cs
@@ -135,8 +135,7 @@ namespace CoreSystems.Support
             }
             catch (Exception e)
             {
-                MyAPIGateway.Utilities.ShowNotification(e.Message, 5000);
-                MyLog.Default.Error($"WC failed to initialize log {name} \n {e.Message}");
+                MyLog.Default.Error($"Exception: WC failed to initialize log {name} \n {e.Message}");
             }
         }
 
@@ -155,7 +154,18 @@ namespace CoreSystems.Support
 
                 using (var write = MyAPIGateway.Utilities.WriteFileInLocalStorage(sb.ToString(), anyObjectInYourMod))
                 {
-                    write.Write(read.ReadToEnd());
+                    int n = 0;
+                    while (read.Peek() != -1)
+                    {
+                        write.Write(Convert.ToChar(read.Read()));
+                        n++;
+
+                        if (n > short.MaxValue)
+                        {
+                            write.Flush();
+                            n = 0;
+                        }
+                    }
                     write.Flush();
                     write.Dispose();
                 }


### PR DESCRIPTION
# Additions
- Added bool `WeaponDef.HardPoint.Other.DisableOwnGridLosCheck`
   - disables checking the weapon's own grid for LOS check... and yes  `DisableLosCheck` *didn't* do this
- Added bool `AmmoDef.GridsTargetSeekersTargetingThis`
  - Adds any smart projectiles targeting this projectile to grid lookup tables to be targeted by point defense
- Added value `ReaquiredTarget` to enum `TrajectoryDef.ApproachDef.Conditions`
  - less than or equal to counterpart to `EnemyTargetLoss`
- Added value `EnemySeekersGreaterThanEqualTo` to enum `TrajectoryDef.ApproachDef.Conditions`
  - returns true when the number of seekers (Smart projectiles) targeting this projectile >= value 
- Added value `EnemySeekersLessThanEqualTo` to enum `TrajectoryDef.ApproachDef.Conditions`
  - returns true when the number of seekers (Smart projectiles) targeting this projectile <= value
- Added value `ForceRetarget` to enum `TrajectoryDef.ApproachDef.StageEvents`
  -Calls NewTarget() when the values are met to force target acquisition
- Added Conditions `EndCondition4`, `EndCondition5` to `TrajectoryDef.ApproachDef.WeightedIdListDef`
  - same as 1/2/3 but this time 4/5
- Added double `End4Value`, `End5Value` to `TrajectoryDef.ApproachDef.WeightedIdListDef`
  - same as 1/2/3 but this time 4/5
- Added `End4WeightMod`, `End5WeightMod` to `TrajectoryDef.ApproachDef.WeightedIdListDef`
  - same as 1/2/3 but this time 4/5
- setting `TrajectoryDef.ApproachDef.WeightedIdListDef`'s EndXWeightMod's to `double.MaxValue` will forcefully choose the given approach if that end condition is met
- Added `WeaponDef.HardPointDef.OtherDef.AllowNoTargetFiring`, which allows firing smart ammos without having a target and without setting the target as test mode (so they can pick new targets that may appear)

# Bugfixes
- Fixed Approaches end condition 3 not actually working (& refactored approach condition code to NOT inline these)
- Fixed Approaches condition Or always returning true if condition 1 or 2 was `Ignore`
- Fixed Approaches `UpOriginDirection` using OriginForward rather than OriginUp
- Fixed log init errors not showing properly and an OOM exception caused when moving logs that were too big
- Fixed issue where projectiles would fail to remove themselves from their target's Seeker list if they were killed