### PR TITLE
Visual Effects Update + netcode bugfixes

### DIFF
--- a/CoreSystems.csproj
+++ b/CoreSystems.csproj
@@ -160,6 +160,9 @@
     <Compile Include="Data\Scripts\CoreSystems\Api\ApiBackend.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>
+    <Compile Include="Data\Scripts\CoreSystems\AudioVisual\AvAdvBillboards.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Compile>
     <Compile Include="Data\Scripts\CoreSystems\AudioVisual\RunAv.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
@@ -1711,7 +1711,7 @@ namespace CoreSystems.Api
                         [ProtoMember(73)] internal bool AlternateModelForwardUp;
                         [ProtoMember(74)] internal ModelRelativeTo ModelForwards;
                         [ProtoMember(75)] internal ModelRelativeTo ModelUp;
-                        [ProtoMember(76)] internal bool ResetModelRotTimeOnTargetReset;
+                        [ProtoMember(76)] internal float ModelMaximumAngleToRotate;
                     }
 
                         [ProtoContract]

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
@@ -1586,6 +1586,7 @@ namespace CoreSystems.Api
                             ModelRelativeToOriginDirection,
                             ModelOriginForwards,
                             ModelOriginUp,
+                            ModelAcceleration,
                         }
                         public enum RelativeTo
                         {

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
@@ -1033,14 +1033,15 @@ namespace CoreSystems.Api
                             [ProtoMember(12)] public float P1RandomOffset;
                             [ProtoMember(13)] public float Width;
                             [ProtoMember(14)] public float RotateSpeed;
-                            [ProtoMember(15)] public float MaxViewDistance;
-                            [ProtoMember(16)] public float AccelerationSizeMultiplier;
-                            [ProtoMember(17)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                            [ProtoMember(18)] public LineDef.FactionColor FactionColor;
-                            [ProtoMember(19)] public string[] Materials;
-                            [ProtoMember(20)] public Vector3 P0;
-                            [ProtoMember(21)] public Vector3 P1;
-                            [ProtoMember(22)] public Vector4 Color;
+                            [ProtoMember(15)] public float MinViewDistance;
+                            [ProtoMember(16)] public float MaxViewDistance;
+                            [ProtoMember(17)] public float AccelerationSizeMultiplier;
+                            [ProtoMember(18)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                            [ProtoMember(19)] public LineDef.FactionColor FactionColor;
+                            [ProtoMember(20)] public string[] Materials;
+                            [ProtoMember(21)] public Vector3 P0;
+                            [ProtoMember(22)] public Vector3 P1;
+                            [ProtoMember(23)] public Vector4 Color;
                         }
                         [ProtoContract]
                         public struct Trail
@@ -1053,12 +1054,13 @@ namespace CoreSystems.Api
                             [ProtoMember(6)] public float RotateSpeed;
                             [ProtoMember(7)] public float P0RandomOffset;
                             [ProtoMember(8)] public float Width;
-                            [ProtoMember(9)] public float MaxViewDistance;
-                            [ProtoMember(10)] public LineDef.FactionColor FactionColor;
-                            [ProtoMember(11)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                            [ProtoMember(12)] public string[] Materials;
-                            [ProtoMember(13)] public Vector3 P0;
-                            [ProtoMember(14)] public Vector4 Color;
+                            [ProtoMember(9)] public float MinViewDistance;
+                            [ProtoMember(10)] public float MaxViewDistance;
+                            [ProtoMember(11)] public LineDef.FactionColor FactionColor;
+                            [ProtoMember(12)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                            [ProtoMember(13)] public string[] Materials;
+                            [ProtoMember(14)] public Vector3 P0;
+                            [ProtoMember(15)] public Vector4 Color;
                         }
                         [ProtoContract]
                         public struct Billboard
@@ -1066,15 +1068,16 @@ namespace CoreSystems.Api
                             [ProtoMember(1)] public bool AlwaysDraw;
                             [ProtoMember(2)] public bool ColorFade;
                             [ProtoMember(3)] public float RotateSpeed;
-                            [ProtoMember(4)] public float MaxViewDistance;
-                            [ProtoMember(5)] public LineDef.FactionColor FactionColor;
-                            [ProtoMember(6)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                            [ProtoMember(7)] public string[] Materials;
-                            [ProtoMember(8)] public Vector3 P0;
-                            [ProtoMember(9)] public Vector3 P1;
-                            [ProtoMember(10)] public Vector3 P2;
-                            [ProtoMember(11)] public Vector3 P3; // P2 == P3 for triangle
-                            [ProtoMember(12)] public Vector4 Color;
+                            [ProtoMember(4)] public float MinViewDistance;
+                            [ProtoMember(5)] public float MaxViewDistance;
+                            [ProtoMember(6)] public LineDef.FactionColor FactionColor;
+                            [ProtoMember(7)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                            [ProtoMember(8)] public string[] Materials;
+                            [ProtoMember(9)] public Vector3 P0;
+                            [ProtoMember(10)] public Vector3 P1;
+                            [ProtoMember(11)] public Vector3 P2;
+                            [ProtoMember(12)] public Vector3 P3; // P2 == P3 for triangle
+                            [ProtoMember(13)] public Vector4 Color;
                         }
                     }
                 }

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
@@ -893,6 +893,7 @@ namespace CoreSystems.Api
                     [ProtoMember(4)] internal AmmoParticleDef Particles;
                     [ProtoMember(5)] internal LineDef Lines;
                     [ProtoMember(6)] internal DecalDef Decals;
+                    [ProtoMember(7)] internal AdvBillboardsDef AdvancedLines;
 
                     [ProtoContract]
                     public struct AmmoParticleDef
@@ -1004,6 +1005,77 @@ namespace CoreSystems.Api
                         {
                             [ProtoMember(1)] internal string HitMaterial;
                             [ProtoMember(2)] internal string DecalMaterial;
+                        }
+                    }
+
+                    [ProtoContract]
+                    public struct AdvBillboardsDef
+                    {
+                        [ProtoMember(1)] internal bool Enable;
+                        [ProtoMember(2)] internal bool UseModelRotation;
+                        [ProtoMember(3)] internal Line[] AdvLines;
+                        [ProtoMember(4)] internal Trail[] AdvTrails;
+                        [ProtoMember(5)] internal Billboard[] Billboards;
+                        [ProtoContract]
+                        public struct Line
+                        {
+                            [ProtoMember(1)] public bool AlwaysDraw;
+                            [ProtoMember(2)] public bool OnlyDrawIfAccelerationAligned;
+                            [ProtoMember(3)] public bool WidthFade;
+                            [ProtoMember(4)] public bool ColorFade;
+                            [ProtoMember(5)] public bool LengthAffectedByAccelAlignment;
+                            [ProtoMember(6)] public bool AccelAccountForGrav;
+                            [ProtoMember(7)] public float AccelerationDotReq;
+                            [ProtoMember(8)] public float VelocityInheritence;
+                            [ProtoMember(9)] public uint TimeRendered;
+                            [ProtoMember(10)] public uint DelayBetweenSpawns;
+                            [ProtoMember(11)] public float P0RandomOffset;
+                            [ProtoMember(12)] public float P1RandomOffset;
+                            [ProtoMember(13)] public float Width;
+                            [ProtoMember(14)] public float RotateSpeed;
+                            [ProtoMember(15)] public float MaxViewDistance;
+                            [ProtoMember(16)] public float AccelerationSizeMultiplier;
+                            [ProtoMember(17)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                            [ProtoMember(18)] public LineDef.FactionColor FactionColor;
+                            [ProtoMember(19)] public string Material;
+                            [ProtoMember(20)] public Vector3 P0;
+                            [ProtoMember(21)] public Vector3 P1;
+                            [ProtoMember(22)] public Vector4 Color;
+                        }
+                        [ProtoContract]
+                        public struct Trail
+                        {
+                            [ProtoMember(1)] public bool WidthFade;
+                            [ProtoMember(2)] public bool ColorFade;
+                            [ProtoMember(3)] public bool AlwaysDraw;
+                            [ProtoMember(4)] public float VelocityInheritence;
+                            [ProtoMember(5)] public uint TimeRendered;
+                            [ProtoMember(6)] public uint DelayBetweenSpawns;
+                            [ProtoMember(7)] public float RotateSpeed;
+                            [ProtoMember(8)] public float P0RandomOffset;
+                            [ProtoMember(9)] public float Width;
+                            [ProtoMember(10)] public float MaxViewDistance;
+                            [ProtoMember(11)] public LineDef.FactionColor FactionColor;
+                            [ProtoMember(12)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                            [ProtoMember(13)] public string Material;
+                            [ProtoMember(14)] public Vector3 P0;
+                            [ProtoMember(15)] public Vector4 Color;
+                        }
+                        [ProtoContract]
+                        public struct Billboard
+                        {
+                            [ProtoMember(1)] public bool AlwaysDraw;
+                            [ProtoMember(2)] public bool ColorFade;
+                            [ProtoMember(3)] public float RotateSpeed;
+                            [ProtoMember(4)] public float MaxViewDistance;
+                            [ProtoMember(5)] public LineDef.FactionColor FactionColor;
+                            [ProtoMember(6)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                            [ProtoMember(7)] public string Material;
+                            [ProtoMember(8)] public Vector3 P0;
+                            [ProtoMember(9)] public Vector3 P1;
+                            [ProtoMember(10)] public Vector3 P2;
+                            [ProtoMember(11)] public Vector3 P3; // P2 == P3 for triangle
+                            [ProtoMember(12)] public Vector4 Color;
                         }
                     }
                 }
@@ -1498,7 +1570,23 @@ namespace CoreSystems.Api
                             ForwardRelativeToShooter,
                             ForwardOriginDirection,
                         }
-
+                        public enum ModelRelativeTo
+                        {
+                            ModelNone = 0,
+                            ModelRelativeToGravity,
+                            ModelTargetDirection,
+                            ModelTargetPredictedDirection,
+                            ModelTargetVelocity,
+                            ModelStoredStartPosition,
+                            ModelStoredEndPosition,
+                            ModelStoredStartLocalPosition,
+                            ModelStoredEndLocalPosition,
+                            ModelRelativeToShooterForwards,
+                            ModelRelativeToShooterUp,
+                            ModelRelativeToOriginDirection,
+                            ModelOriginForwards,
+                            ModelOriginUp,
+                        }
                         public enum RelativeTo
                         {
                             Origin,
@@ -1616,9 +1704,18 @@ namespace CoreSystems.Api
                         [ProtoMember(65)] internal double End3Value;
                         [ProtoMember(66)] internal bool SwapNavigationType;
                         [ProtoMember(67)] internal bool ElevationRelativeToC;
+                        [ProtoMember(68)] internal Conditions EndCondition4;
+                        [ProtoMember(69)] internal double End4Value;
+                        [ProtoMember(70)] internal Conditions EndCondition5;
+                        [ProtoMember(71)] internal double End5Value;
+                        [ProtoMember(72)] internal bool DockOnEnd;
+                        [ProtoMember(73)] internal bool AlternateModelForwardUp;
+                        [ProtoMember(74)] internal ModelRelativeTo ModelForwards;
+                        [ProtoMember(75)] internal ModelRelativeTo ModelUp;
+                        [ProtoMember(76)] internal bool ResetModelRotTimeOnTargetReset;
                     }
 
-                    [ProtoContract]
+                        [ProtoContract]
                     public struct MinesDef
                     {
                         [ProtoMember(1)] internal double DetectRadius;

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
@@ -1037,7 +1037,7 @@ namespace CoreSystems.Api
                             [ProtoMember(16)] public float AccelerationSizeMultiplier;
                             [ProtoMember(17)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
                             [ProtoMember(18)] public LineDef.FactionColor FactionColor;
-                            [ProtoMember(19)] public string Material;
+                            [ProtoMember(19)] public string[] Materials;
                             [ProtoMember(20)] public Vector3 P0;
                             [ProtoMember(21)] public Vector3 P1;
                             [ProtoMember(22)] public Vector4 Color;
@@ -1048,18 +1048,17 @@ namespace CoreSystems.Api
                             [ProtoMember(1)] public bool WidthFade;
                             [ProtoMember(2)] public bool ColorFade;
                             [ProtoMember(3)] public bool AlwaysDraw;
-                            [ProtoMember(4)] public float VelocityInheritence;
-                            [ProtoMember(5)] public uint TimeRendered;
-                            [ProtoMember(6)] public uint DelayBetweenSpawns;
-                            [ProtoMember(7)] public float RotateSpeed;
-                            [ProtoMember(8)] public float P0RandomOffset;
-                            [ProtoMember(9)] public float Width;
-                            [ProtoMember(10)] public float MaxViewDistance;
-                            [ProtoMember(11)] public LineDef.FactionColor FactionColor;
-                            [ProtoMember(12)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                            [ProtoMember(13)] public string Material;
-                            [ProtoMember(14)] public Vector3 P0;
-                            [ProtoMember(15)] public Vector4 Color;
+                            [ProtoMember(4)] public uint TimeRendered;
+                            [ProtoMember(5)] public uint DelayBetweenSpawns;
+                            [ProtoMember(6)] public float RotateSpeed;
+                            [ProtoMember(7)] public float P0RandomOffset;
+                            [ProtoMember(8)] public float Width;
+                            [ProtoMember(9)] public float MaxViewDistance;
+                            [ProtoMember(10)] public LineDef.FactionColor FactionColor;
+                            [ProtoMember(11)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                            [ProtoMember(12)] public string[] Materials;
+                            [ProtoMember(13)] public Vector3 P0;
+                            [ProtoMember(14)] public Vector4 Color;
                         }
                         [ProtoContract]
                         public struct Billboard
@@ -1070,7 +1069,7 @@ namespace CoreSystems.Api
                             [ProtoMember(4)] public float MaxViewDistance;
                             [ProtoMember(5)] public LineDef.FactionColor FactionColor;
                             [ProtoMember(6)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                            [ProtoMember(7)] public string Material;
+                            [ProtoMember(7)] public string[] Materials;
                             [ProtoMember(8)] public Vector3 P0;
                             [ProtoMember(9)] public Vector3 P1;
                             [ProtoMember(10)] public Vector3 P2;

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
@@ -1042,6 +1042,7 @@ namespace CoreSystems.Api
                             [ProtoMember(21)] public Vector3 P0;
                             [ProtoMember(22)] public Vector3 P1;
                             [ProtoMember(23)] public Vector4 Color;
+                            [ProtoMember(24)] public uint DelayBetweenSpawnsOffset;
                         }
                         [ProtoContract]
                         public struct Trail
@@ -1061,6 +1062,7 @@ namespace CoreSystems.Api
                             [ProtoMember(13)] public string[] Materials;
                             [ProtoMember(14)] public Vector3 P0;
                             [ProtoMember(15)] public Vector4 Color;
+                            [ProtoMember(16)] public uint DelayBetweenSpawnsOffset;
                         }
                         [ProtoContract]
                         public struct Billboard
@@ -1076,6 +1078,8 @@ namespace CoreSystems.Api
                             [ProtoMember(9)] public Vector3 P2;
                             [ProtoMember(10)] public Vector3 P3; // P2 == P3 for triangle
                             [ProtoMember(11)] public Vector4 Color;
+                            [ProtoMember(12)] public uint DelayBetweenSpawns;
+                            [ProtoMember(13)] public uint DelayBetweenSpawnsOffset;
                         }
                     }
                 }

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiDefs.cs
@@ -1065,19 +1065,17 @@ namespace CoreSystems.Api
                         [ProtoContract]
                         public struct Billboard
                         {
-                            [ProtoMember(1)] public bool AlwaysDraw;
-                            [ProtoMember(2)] public bool ColorFade;
-                            [ProtoMember(3)] public float RotateSpeed;
-                            [ProtoMember(4)] public float MinViewDistance;
-                            [ProtoMember(5)] public float MaxViewDistance;
-                            [ProtoMember(6)] public LineDef.FactionColor FactionColor;
-                            [ProtoMember(7)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                            [ProtoMember(8)] public string[] Materials;
-                            [ProtoMember(9)] public Vector3 P0;
-                            [ProtoMember(10)] public Vector3 P1;
-                            [ProtoMember(11)] public Vector3 P2;
-                            [ProtoMember(12)] public Vector3 P3; // P2 == P3 for triangle
-                            [ProtoMember(13)] public Vector4 Color;
+                            [ProtoMember(1)] public float RotateSpeed;
+                            [ProtoMember(2)] public float MinViewDistance;
+                            [ProtoMember(3)] public float MaxViewDistance;
+                            [ProtoMember(4)] public LineDef.FactionColor FactionColor;
+                            [ProtoMember(5)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                            [ProtoMember(6)] public string[] Materials;
+                            [ProtoMember(7)] public Vector3 P0;
+                            [ProtoMember(8)] public Vector3 P1;
+                            [ProtoMember(9)] public Vector3 P2;
+                            [ProtoMember(10)] public Vector3 P3; // P2 == P3 for triangle
+                            [ProtoMember(11)] public Vector4 Color;
                         }
                     }
                 }

--- a/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using CoreSystems.Platform;
+using CoreSystems.Projectiles;
+using Sandbox.Game.Entities;
+using Sandbox.ModAPI;
+using VRage.Collections;
+using VRage.Game;
+using VRage.Game.Entity;
+using VRage.Game.ModAPI;
+using VRage.Utils;
+using VRageMath;
+using VRageRender;
+using static VRageRender.MyBillboard;
+using static CoreSystems.Support.WeaponDefinition.AmmoDef.GraphicDef.LineDef;
+using static CoreSystems.Projectiles.Projectile;
+using static CoreSystems.Support.AdvBillboards;
+
+namespace CoreSystems.Support
+{
+    internal class AvAdvBillboards
+    {
+        // REFERENCES TO AMMO DEF!
+        public LineConstants[] LineDefs;
+        public TrailConstants[] TrailDefs;
+        public BillboardConstants[] BillboardDefs;
+
+        public List<AdvBLineCache> DrawnLines = new List<AdvBLineCache>();
+        public List<MyQueue<AdvBLineCache>> Trails = new List<MyQueue<AdvBLineCache>>();
+        public List<MyBillboard> Billboards = new List<MyBillboard>();
+        public AvShot Av;
+        public MatrixD ProjectileMatrix;
+        public Vector3 Velocity;
+        public Vector3 PrevVelocity;
+        public Vector3D PrevPosition;
+        public Vector3 Grav;
+        public int ClientAVLevel;
+        public int CurrentLifetime;
+        public bool ModelRotation;
+
+        const int LONG_TRAIL_THRESHOLD = 100; // kinda arbitrary number, if another number gives better perf change it
+        internal void Init(Projectile p, ProInfo info, AvShot av)
+        {
+            var session = Session.I;
+            var avr = session.Av;
+            Av = av;
+
+            ClientAVLevel = session.ClientAvLevel;
+
+            ModelRotation = info.AmmoDef.Const.AdvBillboardSettings.UseModelRotation;
+            LineDefs = info.AmmoDef.Const.AdvBillboardSettings.Lines;
+            TrailDefs = info.AmmoDef.Const.AdvBillboardSettings.Trails;
+            BillboardDefs = info.AmmoDef.Const.AdvBillboardSettings.Billboards;
+
+            Grav = p.Gravity;
+
+            if (LineDefs.Length > 0)
+            {
+                int maxLines = 0;
+                foreach (var linedef in LineDefs)
+                {
+                    maxLines += (int)Math.Ceiling((float)linedef.TimeRendered / (linedef.DelayBetweenSpawns + 1));
+                }
+                DrawnLines.EnsureCapacity(maxLines);
+            }
+
+            if (TrailDefs.Length > 0)
+            {
+                Trails.EnsureCapacity(TrailDefs.Length);
+                for (int i = 0; i < TrailDefs.Length; i++)
+                {
+                    var trailLineCount = (int)Math.Ceiling((float)TrailDefs[i].TimeRendered / (TrailDefs[i].DelayBetweenSpawns + ClientAVLevel + 1));
+                    var cache = trailLineCount > LONG_TRAIL_THRESHOLD
+                        ? avr.AdvBLongTrailCacheLists.Count > 0 ? avr.AdvBLongTrailCacheLists.Pop() : new MyQueue<AdvBLineCache>(trailLineCount)
+                        : avr.AdvBTrailCacheLists.Count > 0 ? avr.AdvBTrailCacheLists.Pop() : new MyQueue<AdvBLineCache>(trailLineCount);
+
+                    Trails.Add(cache);
+                }
+            }
+
+            if (BillboardDefs.Length > 0)
+            {
+                Billboards.EnsureCapacity(BillboardDefs.Length);
+                for (int i = 0; i < BillboardDefs.Length; i++)
+                {
+                    Billboards.Add(avr.BillboardCache.Count > 0 ? avr.BillboardCache.Pop() : new MyBillboard());
+                }
+            }
+        }
+
+        internal void Clean()
+        {
+            var avr = Session.I.Av;
+
+            avr.AdvBLines.AddRange(DrawnLines);
+            DrawnLines.Clear();
+
+            for (int i = TrailDefs.Length - 1; i >= 0; i--)
+            {
+                var trailLineCount = (int)Math.Ceiling((float)TrailDefs[i].TimeRendered / (TrailDefs[i].DelayBetweenSpawns + ClientAVLevel + 1));
+                var longTrail = trailLineCount > LONG_TRAIL_THRESHOLD;
+
+                for (int j = Trails[i].Count - 1; j >= 0; j--)
+                    avr.AdvBLines.Add(Trails[i][j]);
+
+                Trails[i].Clear();
+
+                if (longTrail)
+                    avr.AdvBLongTrailCacheLists.Push(Trails[i]);
+                else
+                    avr.AdvBTrailCacheLists.Push(Trails[i]);
+            }
+            Trails.Clear();
+            ClientAVLevel = 0;
+            CurrentLifetime = 0;
+
+            foreach (var billboard in Billboards)
+            {
+                avr.BillboardCache.Push(billboard);
+            }
+            Billboards.Clear();
+
+            LineDefs = null;
+            TrailDefs = null;
+            BillboardDefs = null;
+
+            Av = null;
+            ProjectileMatrix = MatrixD.Identity;
+            Velocity = Vector3D.Zero;
+            PrevVelocity = Vector3D.Zero;
+            PrevPosition = Vector3D.Zero;
+            Grav = Vector3.Zero;
+            ClientAVLevel = 0;
+            CurrentLifetime = 0;
+            ModelRotation = false;
+    }
+    }
+    internal class AdvBLineCache
+    {
+        public bool LerpColor;
+        public bool LerpWidth;
+        public bool AlwaysDraw;
+        public uint EndTick;
+        public uint StartTick;
+        public float StartWidth;
+        public float MaxDistSq;
+        public MyStringId Material;
+        public MyBillboard Billboard = new MyBillboard();
+        public Vector3 Velocity;
+        public Vector4 StartColor;
+        public Vector3D Start;
+        public Vector3D End;
+    }
+}

--- a/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
@@ -34,7 +34,7 @@ namespace CoreSystems.Support
         public Vector3 PrevVelocity;
         public Vector3D PrevPosition;
         public Vector3 Grav;
-        public int ClientAVLevel;
+        public uint ClientAVLevel;
         public int CurrentLifetime;
         public bool ModelRotation;
 
@@ -45,7 +45,7 @@ namespace CoreSystems.Support
             var avr = session.Av;
             Av = av;
 
-            ClientAVLevel = session.ClientAvLevel;
+            ClientAVLevel = (uint)session.ClientAvLevel;
 
             ModelRotation = info.AmmoDef.Const.AdvBillboardSettings.UseModelRotation;
             LineDefs = info.AmmoDef.Const.AdvBillboardSettings.Lines;
@@ -53,6 +53,9 @@ namespace CoreSystems.Support
             BillboardDefs = info.AmmoDef.Const.AdvBillboardSettings.Billboards;
 
             Grav = p.Gravity * MyEngineConstants.PHYSICS_STEP_SIZE_IN_SECONDS;
+
+            ProjectileMatrix = MatrixD.CreateWorld(p.Position, (MyUtils.IsZero(p.Velocity, 0.01f) ? p.Direction : p.Velocity).Normalized(), p.Info.OriginUp);
+            PrevPosition = p.Info.Origin;
 
             if (LineDefs.Length > 0)
             {
@@ -115,7 +118,6 @@ namespace CoreSystems.Support
             }
             Trails.Clear();
             ClientAVLevel = 0;
-            CurrentLifetime = 0;
 
             foreach (var billboard in Billboards)
             {
@@ -149,6 +151,7 @@ namespace CoreSystems.Support
         public uint StartTick;
         public float StartWidth;
         public float MaxDistSq;
+        public float SphereDist;
         public MyStringId Material;
         public MyBillboard Billboard = new MyBillboard();
         public Vector3 Velocity;

--- a/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
@@ -27,7 +27,7 @@ namespace CoreSystems.Support
 
         public List<AdvBLineCache> DrawnLines = new List<AdvBLineCache>();
         public List<MyQueue<AdvBLineCache>> Trails = new List<MyQueue<AdvBLineCache>>();
-        public List<MyBillboard> Billboards = new List<MyBillboard>();
+        public List<BillboardInfo> Billboards = new List<BillboardInfo>();
         public AvShot Av;
         public MatrixD ProjectileMatrix;
         public Vector3 Velocity;
@@ -83,7 +83,10 @@ namespace CoreSystems.Support
                 Billboards.EnsureCapacity(BillboardDefs.Length);
                 for (int i = 0; i < BillboardDefs.Length; i++)
                 {
-                    Billboards.Add(avr.BillboardCache.Count > 0 ? avr.BillboardCache.Pop() : new MyBillboard());
+                    var binfo = avr.BillboardCache.Count > 0 ? avr.BillboardCache.Pop() : new BillboardInfo();
+                    binfo.IsTri = BillboardDefs[i].IsTri;
+                    binfo.Render = false;
+                    Billboards.Add(binfo);
                 }
             }
         }
@@ -116,6 +119,8 @@ namespace CoreSystems.Support
 
             foreach (var billboard in Billboards)
             {
+                billboard.IsTri = false;
+                billboard.Render = false;
                 avr.BillboardCache.Push(billboard);
             }
             Billboards.Clear();
@@ -150,5 +155,12 @@ namespace CoreSystems.Support
         public Vector4 StartColor;
         public Vector3D Start;
         public Vector3D End;
+    }
+    // if only this could be value type
+    internal class BillboardInfo
+    {
+        public MyBillboard Billboard;
+        public bool Render;
+        public bool IsTri;
     }
 }

--- a/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
@@ -52,7 +52,7 @@ namespace CoreSystems.Support
             TrailDefs = info.AmmoDef.Const.AdvBillboardSettings.Trails;
             BillboardDefs = info.AmmoDef.Const.AdvBillboardSettings.Billboards;
 
-            Grav = p.Gravity;
+            Grav = p.Gravity * MyEngineConstants.PHYSICS_STEP_SIZE_IN_SECONDS;
 
             if (LineDefs.Length > 0)
             {

--- a/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/AvAdvBillboards.cs
@@ -156,10 +156,10 @@ namespace CoreSystems.Support
         public Vector3D Start;
         public Vector3D End;
     }
-    // if only this could be value type
+    // if only this could be value type :(
     internal class BillboardInfo
     {
-        public MyBillboard Billboard;
+        public MyBillboard Billboard = new MyBillboard();
         public bool Render;
         public bool IsTri;
     }

--- a/Data/Scripts/CoreSystems/AudioVisual/AvShot.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/AvShot.cs
@@ -37,6 +37,7 @@ namespace CoreSystems.Support
         internal MyParticleEffect AmmoEffect;
         internal MyParticleEffect FieldEffect;
         internal Weapon Weapon;
+        internal AvAdvBillboards AdvBillboards;
         internal bool TravelSound;
         internal bool HasTravelSound;
         internal bool HitSoundActive;
@@ -169,7 +170,7 @@ namespace CoreSystems.Support
         }
 
         #region Run
-        internal void Init(ProInfo info, double firstStepSize, double maxSpeed, ref Vector3D originDir)
+        internal void Init(Projectile p, ProInfo info, double firstStepSize, double maxSpeed, ref Vector3D originDir)
         {
             AmmoDef = info.AmmoDef;
             IsFragment = info.IsFragment;
@@ -215,7 +216,7 @@ namespace CoreSystems.Support
                 else
                     DecayTime = defaultDecayTime;
             }
-            else 
+            else
                 DecayTime = defaultDecayTime;
 
             if (AmmoDef.Const.DrawLine) Tracer = !AmmoDef.Const.IsBeamWeapon && firstStepSize < MaxTracerLength && !MyUtils.IsZero(firstStepSize - MaxTracerLength, 1E-01F) ? TracerState.Grow : TracerState.Full;
@@ -234,6 +235,13 @@ namespace CoreSystems.Support
             AvInfoCache infoCache;
             if (AmmoDef.Const.IsBeamWeapon && AmmoDef.Const.TracerMode != AmmoConstants.Texture.Normal && Session.AvShotCache.TryGetValue(info.UniqueMuzzleId, out infoCache))
                 UpdateCache(infoCache);
+
+            if (AmmoDef.Const.DrawAdvBillboards)
+            {
+                AdvBillboards = Session.Av.AvAdvBillboardsEffectPool.Count > 0 ? Session.Av.AvAdvBillboardsEffectPool.Pop() : new AvAdvBillboards();
+                AdvBillboards.Init(p, info, this);
+                Session.Av.AdvBillboards.Add(AdvBillboards);
+            }
         }
 
         internal static void DeferedAvStateUpdates()
@@ -1236,7 +1244,7 @@ namespace CoreSystems.Support
 
                 vp.TracerLength = info.TracerLength;
                 var visDir = aConst.ConvergeBeams ? p.Direction : vp.OriginFwd;
-                vs.Init(vp, (aConst.DeltaVelocityPerTick * Session.I.DeltaTimeRatio), p.MaxSpeed, ref visDir);
+                vs.Init(p, vp, (aConst.DeltaVelocityPerTick * Session.I.DeltaTimeRatio), p.MaxSpeed, ref visDir);
                 if (info.BaseDamagePool <= 0 || p.State == ProjectileState.Depleted)
                     vs.ProEnded = true;
 

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -637,7 +637,7 @@ namespace CoreSystems.Support
                     if (trails.Count > 0)
                     {
                         var lastTrail = trails.Last();
-                        line.End = divisor <= 1 || tick - lastTrail.StartTick <= divisor ? lastTrail.Start : av.PrevPosition + p0Transformed;
+                        line.End = tick - lastTrail.StartTick <= divisor ? lastTrail.Start : av.PrevPosition + p0Transformed;
                     }
                     else
                         line.End = av.PrevPosition + p0Transformed;

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -527,8 +527,8 @@ namespace CoreSystems.Support
                     }
 
 
-                    line.Start = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(P0 + P0RndOffset, mat);
-                    line.End = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(P1 + P1RndOffset, mat);
+                    line.Start = av.ProjectileMatrix.Translation + (MyUtils.IsZero(def.P0) ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(P0 + P0RndOffset, mat));
+                    line.End = av.ProjectileMatrix.Translation + (MyUtils.IsZero(def.P1) ? (Vector3D)P1RndOffset : Vector3D.TransformNormal(P1 + P1RndOffset, mat));
 
                     line.StartWidth = width;
                     line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :
@@ -631,7 +631,7 @@ namespace CoreSystems.Support
                         P0RndOffset = new Vector3(a1sin * a2cos * r, a1sin * a2sin * r, a1cos * r);
                     }
 
-                    var p0Transformed = Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
+                    var p0Transformed = MyUtils.IsZero(def.P0) ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
                     line.Start = av.ProjectileMatrix.Translation + p0Transformed;
 
                     if (trails.Count > 0)

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -384,7 +384,7 @@ namespace CoreSystems.Support
                 {
                     var def = av.LineDefs[j];
                     
-                    if (def.DelayBetweenSpawns != 0 && av.CurrentLifetime % (def.DelayBetweenSpawns + 1) != 0)
+                    if (def.DelayBetweenSpawns != 0 && (av.CurrentLifetime + def.DelayBetweenSpawnsOffset) % (def.DelayBetweenSpawns + 1) != 0)
                         continue;
 
                     if ((def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
@@ -552,7 +552,7 @@ namespace CoreSystems.Support
                         advBLineCooldown.Add(trails.Dequeue());
                     }
                     uint divisor = av.ClientAVLevel + def.DelayBetweenSpawns + 1;
-                    if ((divisor > 1 && av.CurrentLifetime % divisor != 0)
+                    if ((divisor > 1 && (av.CurrentLifetime + def.DelayBetweenSpawnsOffset) % divisor != 0)
                         || (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
                         || (def.MinViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
                     {
@@ -660,6 +660,10 @@ namespace CoreSystems.Support
                     av.Billboards[j].Render = false;
 
                     var def = av.BillboardDefs[j];
+
+                    if (def.DelayBetweenSpawns != 0 && (av.CurrentLifetime + def.DelayBetweenSpawnsOffset) % (def.DelayBetweenSpawns + 1) != 0)
+                        continue;
+
                     if ((def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
                         || (def.MinViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
                     {

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -387,7 +387,8 @@ namespace CoreSystems.Support
                     if (def.DelayBetweenSpawns != 0 && av.CurrentLifetime % (def.DelayBetweenSpawns + 1) != 0)
                         continue;
 
-                    if (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                    if (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)
+                        || (def.MinViewDistanceSq > 0 && def.MinViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
                         continue;
 
                     var mat = av.ProjectileMatrix;
@@ -554,12 +555,13 @@ namespace CoreSystems.Support
                     }
                     uint divisor = (uint)av.ClientAVLevel + def.DelayBetweenSpawns + 1;
                     if (def.DelayBetweenSpawns + av.ClientAVLevel != 0 && av.CurrentLifetime % divisor != 0
-                        || def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                        || (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                        || (def.MinViewDistanceSq > 0 && def.MinViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
                     {
                         if (trails.Count > 0)
                         {
                             var prevTrail = trails.Last();
-                            prevTrail.Start = prevTrail.Start - av.PrevPosition + av.ProjectileMatrix.Translation; // with this simple trick 60 billboard trails can go to like 10 if the modder optimizes
+                            prevTrail.Start = prevTrail.Start - av.PrevPosition + av.ProjectileMatrix.Translation; // with this simple trick I sawed the billboard count in half!
                         }
                         continue;
                     }
@@ -1015,8 +1017,8 @@ namespace CoreSystems.Support
                     for (int i = 0; i < av.BillboardDefs.Length; i++)
                     {
                         var def = av.BillboardDefs[i];
-
-                        if (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, cam.Position))
+                        if ((def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, cam.Position))
+                            || (def.MinViewDistanceSq > 0 && def.MinViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, cam.Position)))
                             continue;
 
                         var mat = av.ProjectileMatrix;
@@ -1032,7 +1034,7 @@ namespace CoreSystems.Support
                             mat = MatrixD.CreateWorld(mat.Translation, mat.Forward, Vector3D.TransformNormal(mat.Up, rotationMat));
                         }
 
-                        bool isTri = def.P2 == def.P3;
+                        bool isTri = def.IsTri;
                         var P0 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P0, mat);
                         var P1 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P1, mat);
                         var P2 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P2, mat);

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -39,7 +39,7 @@ namespace CoreSystems.Support
         internal readonly Stack<MyQueue<AdvBLineCache>> AdvBTrailCacheLists = new Stack<MyQueue<AdvBLineCache>>(128);
         internal readonly List<AdvBLineCache> AdvBLines = new List<AdvBLineCache>(512);
         internal readonly Dictionary<float, MatrixD> ComputedRotationMatricies = new Dictionary<float, MatrixD>();
-        internal readonly Stack<MyBillboard> BillboardCache = new Stack<MyBillboard>(512);
+        internal readonly Stack<BillboardInfo> BillboardCache = new Stack<BillboardInfo>(512);
 
         internal readonly Stack<MyEntity3DSoundEmitter> FireEmitters = new Stack<MyEntity3DSoundEmitter>();
         internal readonly Stack<MyEntity3DSoundEmitter> TravelEmitters = new Stack<MyEntity3DSoundEmitter>();
@@ -644,6 +644,57 @@ namespace CoreSystems.Support
                     advBillboardsAdded += trails.Count;
                 }
 
+                for (int j = 0; j < av.BillboardDefs.Length; j++)
+                {
+                    av.Billboards[j].Render = false;
+
+                    var def = av.BillboardDefs[j];
+                    if ((def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                        || (def.MinViewDistanceSq > 0 && def.MinViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
+                    {
+                        continue;
+                    }
+
+                    var mat = av.ProjectileMatrix;
+                    if (def.HasRotateSpeed)
+                    {
+                        MatrixD rotationMat;
+                        if (!ComputedRotationMatricies.TryGetValue(def.RotateSpeed, out rotationMat))
+                        {
+                            rotationMat = MatrixD.CreateFromAxisAngle(mat.Forward, def.RotateSpeed * av.CurrentLifetime);
+                            ComputedRotationMatricies[def.RotateSpeed] = rotationMat;
+                        }
+
+                        mat = MatrixD.CreateWorld(mat.Translation, mat.Forward, Vector3D.TransformNormal(mat.Up, rotationMat));
+                    }
+
+                    bool isTri = def.IsTri;
+                    var P0 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P0, mat);
+                    var P1 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P1, mat);
+                    var P2 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P2, mat);
+                    var P3 = isTri ? P2 : av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P3, mat);
+
+                    var b = av.Billboards[j].Billboard;
+                    b.Material = def.Materials[av.CurrentLifetime % def.Materials.Length];
+                    b.LocalType = LocalTypeEnum.Custom;
+                    b.Position0 = P0;
+                    b.Position1 = P1;
+                    b.Position2 = P2;
+                    b.Position3 = P3;
+                    b.UVOffset = Vector2.Zero;
+                    b.UVSize = Vector2.One;
+                    b.DistanceSquared = 0;
+                    b.Color = def.FactionColor == FactionColor.DontUse ? def.Color :
+                        def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor : av.Av.BgFactionColor;
+                    b.Reflectivity = 0;
+                    b.CustomViewProjection = -1;
+                    b.ParentID = uint.MaxValue;
+                    b.ColorIntensity = 1f;
+                    b.SoftParticleDistanceScale = 1f;
+                    b.BlendType = BlendTypeEnum.Standard;
+
+                    av.Billboards[j].Render = true;
+                }
                 av.CurrentLifetime++;
                 
                 ComputedRotationMatricies.Clear();
@@ -1012,64 +1063,21 @@ namespace CoreSystems.Support
                     advBillboardsTrails += AddAdvLineBillboards(BillBoardsToAdd, trail, ref testSphere, tick, cam);
                 }
 
-                if (av.BillboardDefs.Length > 0)
+                foreach (var b in av.Billboards)
                 {
-                    for (int i = 0; i < av.BillboardDefs.Length; i++)
+                    if (!b.Render)
+                        continue;
+
+                    var midpoint = b.IsTri ?
+                        (b.Billboard.Position0 + b.Billboard.Position1 + b.Billboard.Position2) / 3 : 
+                        (b.Billboard.Position0 + b.Billboard.Position1 + b.Billboard.Position2 + b.Billboard.Position3) / 4;
+                    testSphere = new BoundingSphereD(midpoint, 1); // just want to test a point
+                    if (cam.IsInFrustum(ref testSphere))
                     {
-                        var def = av.BillboardDefs[i];
-                        if ((def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, cam.Position))
-                            || (def.MinViewDistanceSq > 0 && def.MinViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, cam.Position)))
-                            continue;
-
-                        var mat = av.ProjectileMatrix;
-                        if (def.HasRotateSpeed)
-                        {
-                            MatrixD rotationMat;
-                            if (!ComputedRotationMatricies.TryGetValue(def.RotateSpeed, out rotationMat))
-                            {
-                                rotationMat = MatrixD.CreateFromAxisAngle(mat.Forward, def.RotateSpeed * av.CurrentLifetime);
-                                ComputedRotationMatricies[def.RotateSpeed] = rotationMat;
-                            }
-
-                            mat = MatrixD.CreateWorld(mat.Translation, mat.Forward, Vector3D.TransformNormal(mat.Up, rotationMat));
-                        }
-
-                        bool isTri = def.IsTri;
-                        var P0 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P0, mat);
-                        var P1 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P1, mat);
-                        var P2 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P2, mat);
-                        var P3 = isTri ? P2 : av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P3, mat);
-
-                        var midpoint = isTri ? (P0 + P1 + P2) / 3 : (P0 + P1 + P2 + P3) / 4;
-
-                        testSphere = new BoundingSphereD(midpoint, 1); // just want to test a point
-
-                        if (cam.IsInFrustum(ref testSphere))
-                        {
-                            var b = av.Billboards[i];
-                            b.Material = def.Materials[av.CurrentLifetime % def.Materials.Length];
-                            b.LocalType = LocalTypeEnum.Custom;
-                            b.Position0 = P0;
-                            b.Position1 = P1;
-                            b.Position2 = P2;
-                            b.Position3 = P3;
-                            b.UVOffset = Vector2.Zero;
-                            b.UVSize = Vector2.One;
-                            b.DistanceSquared = Vector3.DistanceSquared(cam.Position, midpoint);
-                            b.Color = def.FactionColor == FactionColor.DontUse ? def.Color :
-                                def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor : av.Av.BgFactionColor;
-                            b.Reflectivity = 0;
-                            b.CustomViewProjection = -1;
-                            b.ParentID = uint.MaxValue;
-                            b.ColorIntensity = 1f;
-                            b.SoftParticleDistanceScale = 1f;
-                            b.BlendType = BlendTypeEnum.Standard;
-
-                            BillBoardsToAdd.Add(b);
-                            advBillboardsDrawn++;
-                        }
+                        b.Billboard.DistanceSquared = (float)Vector3D.DistanceSquared(cam.Position, midpoint);
+                        BillBoardsToAdd.Add(b.Billboard);
+                        advBillboardsDrawn++;
                     }
-                    ComputedRotationMatricies.Clear();
                 }
             }
             if (Session.I.Tick180)

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -527,8 +527,8 @@ namespace CoreSystems.Support
                     }
 
 
-                    line.Start = av.ProjectileMatrix.Translation + (!def.TransformP0 ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(P0 + P0RndOffset, mat));
-                    line.End = av.ProjectileMatrix.Translation + (!def.TransformP1 ? (Vector3D)P1RndOffset : Vector3D.TransformNormal(P1 + P1RndOffset, mat));
+                    line.Start = av.ProjectileMatrix.Translation + (def.TransformP0 ? Vector3D.TransformNormal(P0 + P0RndOffset, mat) : (Vector3D)P0RndOffset);
+                    line.End = av.ProjectileMatrix.Translation + (def.TransformP1 ? Vector3D.TransformNormal(P1 + P1RndOffset, mat) : (Vector3D)P1RndOffset);
 
                     line.StartWidth = width;
                     line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :
@@ -631,7 +631,7 @@ namespace CoreSystems.Support
                         P0RndOffset = new Vector3(a1sin * a2cos * r, a1sin * a2sin * r, a1cos * r);
                     }
 
-                    var p0Transformed = def.TransformP0 ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
+                    var p0Transformed = def.TransformP0 ? Vector3D.TransformNormal(def.P0 + P0RndOffset, mat) : (Vector3D)P0RndOffset;
                     line.Start = av.ProjectileMatrix.Translation + p0Transformed;
 
                     if (trails.Count > 0)

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -627,9 +627,9 @@ namespace CoreSystems.Support
                         P0RndOffset = new Vector3(a1sin * a2cos * r, a1sin * a2sin * r, a1cos * r);
                     }
 
-
-                    line.Start = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
-                    line.End = trails.Count > 0 ? trails.Last().Start : av.PrevPosition + Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
+                    var p0Transformed = Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
+                    line.Start = av.ProjectileMatrix.Translation + p0Transformed;
+                    line.End = trails.Count > 0 ? trails.Last().Start : av.PrevPosition + p0Transformed;
 
                     line.StartWidth = def.Width;
                     line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -338,6 +338,12 @@ namespace CoreSystems.Support
                     advBLineCooldown.Add(AdvBLines[j]);
                     AdvBLines.RemoveAtFast(j);
                 }
+                else
+                {
+                    var vel = AdvBLines[j].Velocity;
+                    AdvBLines[j].Start += vel;
+                    AdvBLines[j].End += vel;
+                }
             }
 
             int advBillboardsAdded = AdvBLines.Count;
@@ -365,6 +371,12 @@ namespace CoreSystems.Support
                     {
                         advBLineCooldown.Add(av.DrawnLines[j]);
                         av.DrawnLines.RemoveAtFast(j);
+                    }
+                    else
+                    {
+                        var vel = av.DrawnLines[j].Velocity;
+                        av.DrawnLines[j].Start += vel;
+                        av.DrawnLines[j].End += vel;
                     }
                 }
 
@@ -522,7 +534,7 @@ namespace CoreSystems.Support
                         def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor * def.Color : av.Av.BgFactionColor * def.Color;
 
                     line.Velocity = av.Velocity * def.VelocityInheritence * MyEngineConstants.PHYSICS_STEP_SIZE_IN_SECONDS;
-                    line.Material = def.Material;
+                    line.Material = def.Materials[(tick  / (def.DelayBetweenSpawns + 1)) % def.Materials.Length];
 
                     av.DrawnLines.Add(line);
                 }
@@ -540,8 +552,8 @@ namespace CoreSystems.Support
                     {
                         advBLineCooldown.Add(trails.Dequeue());
                     }
-
-                    if (def.DelayBetweenSpawns + av.ClientAVLevel != 0 && av.CurrentLifetime % (def.DelayBetweenSpawns + 1 + av.ClientAVLevel) != 0
+                    uint divisor = (uint)av.ClientAVLevel + def.DelayBetweenSpawns + 1;
+                    if (def.DelayBetweenSpawns + av.ClientAVLevel != 0 && av.CurrentLifetime % divisor != 0
                         || def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
                     {
                         if (trails.Count > 0)
@@ -623,8 +635,8 @@ namespace CoreSystems.Support
                     line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :
                         def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor * def.Color : av.Av.BgFactionColor * def.Color;
 
-                    line.Velocity = av.Velocity * def.VelocityInheritence * MyEngineConstants.PHYSICS_STEP_SIZE_IN_SECONDS;
-                    line.Material = def.Material;
+                    line.Velocity = Vector3.Zero;
+                    line.Material = def.Materials[(tick / divisor) % def.Materials.Length];
 
                     trails.Enqueue(line);
                     advBillboardsAdded += trails.Count;
@@ -1033,7 +1045,7 @@ namespace CoreSystems.Support
                         if (cam.IsInFrustum(ref testSphere))
                         {
                             var b = av.Billboards[i];
-                            b.Material = def.Material;
+                            b.Material = def.Materials[tick % def.Materials.Length];
                             b.LocalType = LocalTypeEnum.Custom;
                             b.Position0 = P0;
                             b.Position1 = P1;

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -387,8 +387,8 @@ namespace CoreSystems.Support
                     if (def.DelayBetweenSpawns != 0 && av.CurrentLifetime % (def.DelayBetweenSpawns + 1) != 0)
                         continue;
 
-                    if (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)
-                        || (def.MinViewDistanceSq > 0 && def.MinViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
+                    if ((def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                        || (def.MinViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
                         continue;
 
                     var mat = av.ProjectileMatrix;
@@ -554,14 +554,16 @@ namespace CoreSystems.Support
                         advBLineCooldown.Add(trails.Dequeue());
                     }
                     uint divisor = (uint)av.ClientAVLevel + def.DelayBetweenSpawns + 1;
-                    if (def.DelayBetweenSpawns + av.ClientAVLevel != 0 && av.CurrentLifetime % divisor != 0
-                        || (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
-                        || (def.MinViewDistanceSq > 0 && def.MinViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
+                    if ((divisor > 1 && av.CurrentLifetime % divisor != 0)
+                        || (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                        || (def.MinViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
                     {
+                        
                         if (trails.Count > 0)
                         {
                             var prevTrail = trails.Last();
-                            prevTrail.Start = prevTrail.Start - av.PrevPosition + av.ProjectileMatrix.Translation; // with this simple trick I sawed the billboard count in half!
+                            if (tick - prevTrail.StartTick <= divisor) // only extend trail up to divisor ticks so it doesn't bug out when rapidly traversing min/max view dists
+                                prevTrail.Start = prevTrail.Start - av.PrevPosition + av.ProjectileMatrix.Translation; // with this simple trick I sawed the billboard count in half!
                         }
                         continue;
                     }
@@ -631,11 +633,18 @@ namespace CoreSystems.Support
 
                     var p0Transformed = Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
                     line.Start = av.ProjectileMatrix.Translation + p0Transformed;
-                    line.End = trails.Count > 0 ? trails.Last().Start : av.PrevPosition + p0Transformed;
+
+                    if (trails.Count > 0)
+                    {
+                        var lastTrail = trails.Last();
+                        line.End = divisor <= 1 || tick - lastTrail.StartTick <= divisor ? lastTrail.Start : av.PrevPosition + p0Transformed;
+                    }
+                    else
+                        line.End = av.PrevPosition + p0Transformed;
 
                     line.StartWidth = def.Width;
                     line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :
-                        def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor * def.Color : av.Av.BgFactionColor * def.Color;
+                    def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor * def.Color : av.Av.BgFactionColor * def.Color;
 
                     line.Velocity = Vector3.Zero;
                     line.Material = def.Materials[(av.CurrentLifetime / divisor) % def.Materials.Length];
@@ -649,8 +658,8 @@ namespace CoreSystems.Support
                     av.Billboards[j].Render = false;
 
                     var def = av.BillboardDefs[j];
-                    if ((def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
-                        || (def.MinViewDistanceSq > 0 && def.MinViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
+                    if ((def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                        || (def.MinViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
                     {
                         continue;
                     }

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -379,11 +379,11 @@ namespace CoreSystems.Support
                         av.DrawnLines[j].End += vel;
                     }
                 }
-
+                
                 for (int j = 0; j < av.LineDefs.Length; j++)
                 {
                     var def = av.LineDefs[j];
-
+                    
                     if (def.DelayBetweenSpawns != 0 && av.CurrentLifetime % (def.DelayBetweenSpawns + 1) != 0)
                         continue;
 
@@ -536,6 +536,7 @@ namespace CoreSystems.Support
 
                     line.Velocity = av.Velocity * def.VelocityInheritence * MyEngineConstants.PHYSICS_STEP_SIZE_IN_SECONDS;
                     line.Material = def.Materials[(av.CurrentLifetime / (def.DelayBetweenSpawns + 1)) % def.Materials.Length];
+                    line.SphereDist = (float)Vector3D.Distance(line.Start, line.End) / 2;
 
                     av.DrawnLines.Add(line);
                 }
@@ -546,14 +547,11 @@ namespace CoreSystems.Support
                     var def = av.TrailDefs[j];
                     var trails = av.Trails[j];
 
-                    if (MyUtils.IsZero(av.PrevPosition)) // first tick
-                        continue;
-
                     if (trails.Count > 0 && trails.Peek().EndTick <= tick)
                     {
                         advBLineCooldown.Add(trails.Dequeue());
                     }
-                    uint divisor = (uint)av.ClientAVLevel + def.DelayBetweenSpawns + 1;
+                    uint divisor = av.ClientAVLevel + def.DelayBetweenSpawns + 1;
                     if ((divisor > 1 && av.CurrentLifetime % divisor != 0)
                         || (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq < Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
                         || (def.MinViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos)))
@@ -563,7 +561,10 @@ namespace CoreSystems.Support
                         {
                             var prevTrail = trails.Last();
                             if (tick - prevTrail.StartTick <= divisor) // only extend trail up to divisor ticks so it doesn't bug out when rapidly traversing min/max view dists
+                            {
                                 prevTrail.Start = prevTrail.Start - av.PrevPosition + av.ProjectileMatrix.Translation; // with this simple trick I sawed the billboard count in half!
+                                prevTrail.SphereDist = (float)Vector3D.Distance(prevTrail.Start, prevTrail.End) / 2;
+                            }
                         }
                         continue;
                     }
@@ -648,6 +649,7 @@ namespace CoreSystems.Support
 
                     line.Velocity = Vector3.Zero;
                     line.Material = def.Materials[(av.CurrentLifetime / divisor) % def.Materials.Length];
+                    line.SphereDist = (float)Vector3D.Distance(line.Start, line.End) / 2;
 
                     trails.Enqueue(line);
                     advBillboardsAdded += trails.Count;
@@ -1006,7 +1008,7 @@ namespace CoreSystems.Support
             foreach (var line in lines)
             {
                 var midpoint = (line.End + line.Start) * 0.5f;
-                testSphere = new BoundingSphereD(midpoint, 1); // just want to test a point
+                testSphere = new BoundingSphereD(midpoint, line.SphereDist); // just want to test a point
                 if (cam.IsInFrustum(ref testSphere))
                 {
                     var b = line.Billboard;
@@ -1018,9 +1020,9 @@ namespace CoreSystems.Support
                     var color = line.StartColor * oneMinust;
                     var width = line.StartWidth * oneMinust;
 
-                    var d = cam.Position - midpoint;
-                    var dist = d.Normalize();
-                    var up = Vector3D.Cross(line.Start - line.End, d).Normalized() * width;
+                    var delta = cam.Position - line.Start;
+                    var dist = delta.Normalize();
+                    var up = MyUtils.GetVector3Scaled(Vector3D.Cross(line.Start - line.End, delta), width);
 
                     b.Material = line.Material;
                     b.LocalType = LocalTypeEnum.Custom;

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -527,8 +527,8 @@ namespace CoreSystems.Support
                     }
 
 
-                    line.Start = av.ProjectileMatrix.Translation + (def.TransformP0 ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(P0 + P0RndOffset, mat));
-                    line.End = av.ProjectileMatrix.Translation + (def.TransformP1 ? (Vector3D)P1RndOffset : Vector3D.TransformNormal(P1 + P1RndOffset, mat));
+                    line.Start = av.ProjectileMatrix.Translation + (!def.TransformP0 ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(P0 + P0RndOffset, mat));
+                    line.End = av.ProjectileMatrix.Translation + (!def.TransformP1 ? (Vector3D)P1RndOffset : Vector3D.TransformNormal(P1 + P1RndOffset, mat));
 
                     line.StartWidth = width;
                     line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -534,7 +534,7 @@ namespace CoreSystems.Support
                         def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor * def.Color : av.Av.BgFactionColor * def.Color;
 
                     line.Velocity = av.Velocity * def.VelocityInheritence * MyEngineConstants.PHYSICS_STEP_SIZE_IN_SECONDS;
-                    line.Material = def.Materials[(tick  / (def.DelayBetweenSpawns + 1)) % def.Materials.Length];
+                    line.Material = def.Materials[(av.CurrentLifetime / (def.DelayBetweenSpawns + 1)) % def.Materials.Length];
 
                     av.DrawnLines.Add(line);
                 }
@@ -636,7 +636,7 @@ namespace CoreSystems.Support
                         def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor * def.Color : av.Av.BgFactionColor * def.Color;
 
                     line.Velocity = Vector3.Zero;
-                    line.Material = def.Materials[(tick / divisor) % def.Materials.Length];
+                    line.Material = def.Materials[(av.CurrentLifetime / divisor) % def.Materials.Length];
 
                     trails.Enqueue(line);
                     advBillboardsAdded += trails.Count;
@@ -1045,7 +1045,7 @@ namespace CoreSystems.Support
                         if (cam.IsInFrustum(ref testSphere))
                         {
                             var b = av.Billboards[i];
-                            b.Material = def.Materials[tick % def.Materials.Length];
+                            b.Material = def.Materials[av.CurrentLifetime % def.Materials.Length];
                             b.LocalType = LocalTypeEnum.Custom;
                             b.Position0 = P0;
                             b.Position1 = P1;

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -12,6 +12,9 @@ using VRageRender;
 using static VRageRender.MyBillboard;
 using static CoreSystems.Support.WeaponDefinition.AmmoDef.GraphicDef.LineDef;
 using static CoreSystems.Support.WeaponDefinition;
+using VRage.Collections;
+using VRage.ModAPI;
+using System;
 namespace CoreSystems.Support
 {
     class RunAv
@@ -28,6 +31,15 @@ namespace CoreSystems.Support
         internal readonly Stack<QuadCache> QuadCachePool = new Stack<QuadCache>(128);
         internal readonly Stack<List<Vector3D>> OffSetLists = new Stack<List<Vector3D>>(128);
 
+        internal readonly Stack<AvAdvBillboards> AvAdvBillboardsEffectPool = new Stack<AvAdvBillboards>(512);
+        internal readonly List<AvAdvBillboards> AdvBillboards = new List<AvAdvBillboards>(512);
+        internal readonly Stack<AdvBLineCache> AdvBLinesPool = new Stack<AdvBLineCache>(512);
+        internal readonly List<AdvBLineCache>[] AdvBLineCacheCooldown = new List<AdvBLineCache>[5];
+        internal readonly Stack<MyQueue<AdvBLineCache>> AdvBLongTrailCacheLists = new Stack<MyQueue<AdvBLineCache>>(32);
+        internal readonly Stack<MyQueue<AdvBLineCache>> AdvBTrailCacheLists = new Stack<MyQueue<AdvBLineCache>>(128);
+        internal readonly List<AdvBLineCache> AdvBLines = new List<AdvBLineCache>(512);
+        internal readonly Dictionary<float, MatrixD> ComputedRotationMatricies = new Dictionary<float, MatrixD>();
+        internal readonly Stack<MyBillboard> BillboardCache = new Stack<MyBillboard>(512);
 
         internal readonly Stack<MyEntity3DSoundEmitter> FireEmitters = new Stack<MyEntity3DSoundEmitter>();
         internal readonly Stack<MyEntity3DSoundEmitter> TravelEmitters = new Stack<MyEntity3DSoundEmitter>();
@@ -73,6 +85,9 @@ namespace CoreSystems.Support
 
             for (int i = 0; i < QuadCacheCoolDown.Length; i++)
                 QuadCacheCoolDown[i] = new List<QuadCache>();
+
+            for (int i = 0; i < AdvBLineCacheCooldown.Length; i++)
+                AdvBLineCacheCooldown[i] = new List<AdvBLineCache>();
         }
 
         private int _onScreens;
@@ -270,36 +285,36 @@ namespace CoreSystems.Support
         {
             UpdateOneFrameQuads();
 
-                if (ActiveBillBoards.Count > 0 || PreAddPersistent.Count > 0)
+            if (ActiveBillBoards.Count > 0 || PreAddPersistent.Count > 0)
                 MyTransparentGeometry.ApplyActionOnPersistentBillboards(UpdatePersistentQuads);
 
-                if (Session.I.Tick10 && Session.I.DebugMod && false)
+            if (Session.I.Tick10 && Session.I.DebugMod && false)
+            {
+                var os = 0;
+                var m = 0;
+                var d = 0;
+                var p = 0;
+                var t = 0;
+                foreach (var a in AvShots)
                 {
-                    var os = 0;
-                    var m = 0;
-                    var d = 0;
-                    var p = 0;
-                    var t = 0;
-                    foreach (var a in AvShots)
-                    {
-                        if (a.OnScreen == AvShot.Screen.None)
-                            os++;
+                    if (a.OnScreen == AvShot.Screen.None)
+                        os++;
 
-                        if (a.MarkForClose)
-                            m++;
+                    if (a.MarkForClose)
+                        m++;
 
-                        if (a.EndState.Dirty)
-                            d++;
+                    if (a.EndState.Dirty)
+                        d++;
 
-                        if (a.OnScreen == AvShot.Screen.ProxyDraw)
-                            p++;
+                    if (a.OnScreen == AvShot.Screen.ProxyDraw)
+                        p++;
 
-                        if (a.TrailSteps.Count > 0)
-                            t++;
-                    }
-                    Session.I.ShowLocalNotify($"cacheRemaining:{QuadCachePool.Count} - onScreen:{_onScreens}({os})[{p}] - hasTrail:{t} - dirty:{d} - marked:{m}", 160);
-
+                    if (a.TrailSteps.Count > 0)
+                        t++;
                 }
+                Session.I.ShowLocalNotify($"cacheRemaining:{QuadCachePool.Count} - onScreen:{_onScreens}({os})[{p}] - hasTrail:{t} - dirty:{d} - marked:{m}", 160);
+
+            }
         }
 
         internal void Run()
@@ -310,6 +325,316 @@ namespace CoreSystems.Support
                 _previousTrailCount = 0;
                 _shrinks = 0;
             }
+            
+            
+            uint tick = Session.I.Tick;
+            var advBLineCooldown = AdvBLineCacheCooldown[Session.I.Tick % AdvBLineCacheCooldown.Length];
+
+
+            for (int j = AdvBLines.Count - 1; j >= 0; j--)
+            {
+                if (AdvBLines[j].EndTick <= tick)
+                {
+                    advBLineCooldown.Add(AdvBLines[j]);
+                    AdvBLines.RemoveAtFast(j);
+                }
+            }
+
+            int advBillboardsAdded = AdvBLines.Count;
+            var camPos = Session.I.CameraPos;
+            for (int i = AdvBillboards.Count - 1; i >= 0; i--)
+            {
+                var av = AdvBillboards[i];
+                var rnd = av?.Av?.AmmoDef?.Const?.Random;
+
+                if (rnd == null || av.Av.MarkForClose)
+                {
+                    AdvBillboards.RemoveAtFast(i);
+                    av.Av.AdvBillboards = null;
+                    av.Clean();
+                    continue;
+                }
+
+                advBillboardsAdded += av.Billboards.Count;
+                bool calculatedAccel = false;
+                Vector3 accel = Vector3D.Zero;
+
+                for (int j = av.DrawnLines.Count - 1; j >= 0; j--)
+                {
+                    if (av.DrawnLines[j].EndTick <= tick)
+                    {
+                        advBLineCooldown.Add(av.DrawnLines[j]);
+                        av.DrawnLines.RemoveAtFast(j);
+                    }
+                }
+
+                for (int j = 0; j < av.LineDefs.Length; j++)
+                {
+                    var def = av.LineDefs[j];
+
+                    if (def.DelayBetweenSpawns != 0 && av.CurrentLifetime % (def.DelayBetweenSpawns + 1) != 0)
+                        continue;
+
+                    if (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                        continue;
+
+                    var mat = av.ProjectileMatrix;
+                    mat.Translation = Vector3D.Zero;
+
+                    var P0 = def.P0;
+                    var P1 = def.P1;
+                    var width = def.Width;
+                    if (def.HasRotateSpeed)
+                    {
+                        MatrixD rotationMat;
+                        if (!ComputedRotationMatricies.TryGetValue(def.RotateSpeed, out rotationMat))
+                        {
+                            rotationMat = MatrixD.CreateFromAxisAngle(mat.Forward, def.RotateSpeed * av.CurrentLifetime);
+                            ComputedRotationMatricies[def.RotateSpeed] = rotationMat;
+                        }
+
+                        mat = MatrixD.CreateWorld(Vector3D.Zero, mat.Forward, Vector3D.TransformNormal(mat.Up, rotationMat));
+                    }
+                    if (def.OnlyDrawIfAccelerationAligned)
+                    {
+                        if (!calculatedAccel)
+                        {
+                            accel = Vector3D.TransformNormal((av.Velocity - av.PrevVelocity) * 0.5f - (def.AccelAccountForGrav ? av.Grav : Vector3.Zero), MatrixD.Transpose(mat));
+                            calculatedAccel = true;
+                        }
+
+                        var dir = P1 - P0;
+                        float dotProduct;
+                        if (def.LengthAffectedByAccelAlignment)
+                        {
+                            var len = dir.Normalize();
+                            dotProduct = Vector3.Dot(accel * def.AccelerationSizeMultiplier, dir);
+
+                            var len2 = Math.Min(len, Math.Abs(dotProduct));
+                            P1 = P0 + dir * len2;
+                            width *= len2 / len;
+                        }
+                        else
+                        {
+                            dotProduct = Vector3.Dot(accel * def.AccelerationSizeMultiplier, dir);
+                        }
+
+                        if (dotProduct >= def.AccelerationDotReq)
+                            continue;
+                    }
+                    
+
+                    var line = AdvBLinesPool.Count > 0 ? AdvBLinesPool.Pop() : new AdvBLineCache();
+
+                    line.LerpColor = def.ColorFade;
+                    line.LerpWidth = def.WidthFade;
+                    line.AlwaysDraw = def.AlwaysDraw;
+                    line.StartTick = tick;
+                    line.EndTick = tick + def.TimeRendered;
+
+                    // pov mod profiler
+                    Vector3 P0RndOffset = Vector3.Zero, P1RndOffset = Vector3.Zero;
+                    if (def.P0RandomOffset > 0)
+                    {
+                        // gross inlined random
+                        var tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        var tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        var tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var angle1 = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * MathHelper.Pi;
+
+                        // gross inlined random
+                        tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var angle2 = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * MathHelper.TwoPi;
+
+                        // gross inlined random
+                        tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var r = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * 2 * def.P0RandomOffset - def.P0RandomOffset;
+
+                        var a1sin = MyMath.FastSin(angle1);
+                        var a2sin = MyMath.FastSin(angle2);
+                        var a1cos = MyMath.FastCos(angle1);
+                        var a2cos = MyMath.FastCos(angle2);
+
+                        P0RndOffset = new Vector3(a1sin * a2cos * r, a1sin * a2sin * r, a1cos * r);
+                    }
+                    if (def.P1RandomOffset > 0)
+                    {
+                        // gross inlined random
+                        var tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        var tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        var tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var angle1 = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * MathHelper.Pi;
+
+                        // gross inlined random
+                        tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var angle2 = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * MathHelper.TwoPi;
+
+                        // gross inlined random
+                        tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var r = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * 2 * def.P1RandomOffset - def.P1RandomOffset;
+
+                        var a1sin = MyMath.FastSin(angle1);
+                        var a2sin = MyMath.FastSin(angle2);
+                        var a1cos = MyMath.FastCos(angle1);
+                        var a2cos = MyMath.FastCos(angle2);
+
+                        P1RndOffset = new Vector3(a1sin * a2cos * r, a1sin * a2sin * r, a1cos * r);
+                    }
+
+
+                    line.Start = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(P0 + P0RndOffset, mat);
+                    line.End = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(P1 + P1RndOffset, mat);
+
+                    line.StartWidth = width;
+                    line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :
+                        def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor * def.Color : av.Av.BgFactionColor * def.Color;
+
+                    line.Velocity = av.Velocity * def.VelocityInheritence * MyEngineConstants.PHYSICS_STEP_SIZE_IN_SECONDS;
+                    line.Material = def.Material;
+
+                    av.DrawnLines.Add(line);
+                }
+                advBillboardsAdded += av.DrawnLines.Count;
+
+                for (int j = 0; j < av.TrailDefs.Length; j++)
+                {
+                    var def = av.TrailDefs[j];
+                    var trails = av.Trails[j];
+
+                    if (MyUtils.IsZero(av.PrevPosition)) // first tick
+                        continue;
+
+                    if (trails.Count > 0 && trails.Peek().EndTick <= tick)
+                    {
+                        advBLineCooldown.Add(trails.Dequeue());
+                    }
+
+                    if (def.DelayBetweenSpawns + av.ClientAVLevel != 0 && av.CurrentLifetime % (def.DelayBetweenSpawns + 1 + av.ClientAVLevel) != 0
+                        || def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, camPos))
+                    {
+                        if (trails.Count > 0)
+                        {
+                            var prevTrail = trails.Last();
+                            prevTrail.Start = prevTrail.Start - av.PrevPosition + av.ProjectileMatrix.Translation; // with this simple trick 60 billboard trails can go to like 10 if the modder optimizes
+                        }
+                        continue;
+                    }
+
+                    var line = AdvBLinesPool.Count > 0 ? AdvBLinesPool.Pop() : new AdvBLineCache();
+
+                    line.LerpColor = def.ColorFade;
+                    line.LerpWidth = def.WidthFade;
+                    line.AlwaysDraw = def.AlwaysDraw;
+                    line.StartTick = tick;
+                    line.EndTick = tick + def.TimeRendered;
+
+                    var mat = av.ProjectileMatrix;
+                    if (def.HasRotateSpeed)
+                    {
+                        MatrixD rotationMat;
+                        if (!ComputedRotationMatricies.TryGetValue(def.RotateSpeed, out rotationMat))
+                        {
+                            rotationMat = MatrixD.CreateFromAxisAngle(mat.Forward, def.RotateSpeed * av.CurrentLifetime);
+                            ComputedRotationMatricies[def.RotateSpeed] = rotationMat;
+                        }
+
+                        mat = MatrixD.CreateWorld(mat.Translation, mat.Forward, Vector3D.TransformNormal(mat.Up, rotationMat));
+                    }
+
+                    // pov mod profiler
+                    Vector3 P0RndOffset = Vector3.Zero;
+                    if (def.P0RandomOffset > 0)
+                    {
+                        // gross inlined random
+                        var tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        var tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        var tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var angle1 = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * MathHelper.Pi;
+
+                        // gross inlined random
+                        tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var angle2 = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * MathHelper.TwoPi;
+
+                        // gross inlined random
+                        tempX = rnd.Y;
+                        rnd.X ^= rnd.X << 23;
+                        tempY = rnd.X ^ rnd.Y ^ (rnd.X >> 17) ^ (rnd.Y >> 26);
+                        tempZ = tempY + rnd.Y;
+                        rnd.X = tempX;
+                        rnd.Y = tempY;
+
+                        var r = (float)XorShiftRandom.DoubleUnit * (0x7FFFFFFF & tempZ) * 2 * def.P0RandomOffset - def.P0RandomOffset;
+
+                        var a1sin = MyMath.FastSin(angle1);
+                        var a2sin = MyMath.FastSin(angle2);
+                        var a1cos = MyMath.FastCos(angle1);
+                        var a2cos = MyMath.FastCos(angle2);
+
+                        P0RndOffset = new Vector3(a1sin * a2cos * r, a1sin * a2sin * r, a1cos * r);
+                    }
+
+
+                    line.Start = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
+                    line.End = trails.Count > 0 ? trails.Last().Start : av.PrevPosition + Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
+
+                    line.StartWidth = def.Width;
+                    line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :
+                        def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor * def.Color : av.Av.BgFactionColor * def.Color;
+
+                    line.Velocity = av.Velocity * def.VelocityInheritence * MyEngineConstants.PHYSICS_STEP_SIZE_IN_SECONDS;
+                    line.Material = def.Material;
+
+                    trails.Enqueue(line);
+                    advBillboardsAdded += trails.Count;
+                }
+
+                av.CurrentLifetime++;
+                
+                ComputedRotationMatricies.Clear();
+            }
+
             _onScreens = 0;
             _models = 0;
             for (int i = AvShots.Count - 1; i >= 0; i--)
@@ -318,11 +643,9 @@ namespace CoreSystems.Support
                 if (av.OnScreen != AvShot.Screen.None && av.OnScreen != AvShot.Screen.ProxyDraw) _onScreens++;
                 var refreshed = av.LastTick == Session.I.Tick;
                 var aConst = av.AmmoDef.Const;
-                var overDrawLimit = PreAddOneFrame.Count > 32000;
+                var overDrawLimit = PreAddOneFrame.Count + advBillboardsAdded > 32000;
                 if (overDrawLimit && av.Offsets?.Count > 0)
                     av.Offsets.Clear();
-
-
 
                 if (refreshed && av.Tracer != AvShot.TracerState.Off && av.OnScreen != AvShot.Screen.None && !overDrawLimit)
                 {
@@ -603,15 +926,206 @@ namespace CoreSystems.Support
             if (av.TracerShrinks.Count == 0) av.ResetHit();
         }
 
+        internal int AddAdvLineBillboards(List<MyBillboard> BillBoardsToAdd, IEnumerable<AdvBLineCache> lines, ref BoundingSphereD testSphere, uint tick, IMyCamera cam)
+        {
+            int ret = 0;
+            foreach (var line in lines)
+            {
+                var midpoint = (line.End + line.Start) * 0.5f;
+                testSphere = new BoundingSphereD(midpoint, 1); // just want to test a point
+                if (cam.IsInFrustum(ref testSphere))
+                {
+                    var b = line.Billboard;
+                    float oneMinust = 1;
+                    if (line.LerpColor || line.LerpWidth)
+                    {
+                        oneMinust = 1 - (float)(tick - line.StartTick) / (line.EndTick - line.StartTick);
+                    }
+                    var color = line.StartColor * oneMinust;
+                    var width = line.StartWidth * oneMinust;
+
+                    var d = cam.Position - midpoint;
+                    var dist = d.Normalize();
+                    var up = Vector3D.Cross(line.Start - line.End, d).Normalized() * width;
+
+                    b.Material = line.Material;
+                    b.LocalType = LocalTypeEnum.Custom;
+                    b.Position0 = line.Start - up;
+                    b.Position1 = line.End   - up;
+                    b.Position2 = line.End   + up;
+                    b.Position3 = line.Start + up;
+                    b.UVOffset = Vector2.Zero;
+                    b.UVSize = Vector2.One;
+                    b.DistanceSquared = (float)(dist * dist);
+                    b.Color = color;
+                    b.Reflectivity = 0;
+                    b.CustomViewProjection = -1;
+                    b.ParentID = uint.MaxValue;
+                    b.ColorIntensity = 1f;
+                    b.SoftParticleDistanceScale = 1f;
+                    b.BlendType = BlendTypeEnum.Standard;
+
+                    BillBoardsToAdd.Add(b);
+                    ret++;
+                }
+
+                line.Start += line.Velocity;
+                line.End += line.Velocity;
+            }
+            return ret;
+        }
+        
         internal void UpdateOneFrameQuads()
         {
+            BoundingSphereD testSphere = new BoundingSphereD();
+            
+            var cam = Session.I.Camera;
+            var tick = Session.I.Tick;
+            int advBillboardsDrawn = 0;
+            int advBillboardsLines = 0;
+            int advBillboardsTrails = 0;
+            int advBillboardsOrphans = AddAdvLineBillboards(BillBoardsToAdd, AdvBLines, ref testSphere, tick, cam);
+            // manually test every line as these may be far from the actual projectile
+            // and frustum check is relatively quick compared to how slow rendering a billboard is (thanks keen)
+            for (int n = 0; n < AdvBillboards.Count; n++)
+            {
+                var av = AdvBillboards[n];
+
+                advBillboardsLines += AddAdvLineBillboards(BillBoardsToAdd, av.DrawnLines, ref testSphere, tick, cam);
+
+                foreach (var trail in av.Trails)
+                {
+                    advBillboardsTrails += AddAdvLineBillboards(BillBoardsToAdd, trail, ref testSphere, tick, cam);
+                }
+
+                if (av.BillboardDefs.Length > 0)
+                {
+                    for (int i = 0; i < av.BillboardDefs.Length; i++)
+                    {
+                        var def = av.BillboardDefs[i];
+
+                        if (def.MaxViewDistanceSq > 0 && def.MaxViewDistanceSq > Vector3D.DistanceSquared(av.ProjectileMatrix.Translation, cam.Position))
+                            continue;
+
+                        var mat = av.ProjectileMatrix;
+                        if (def.HasRotateSpeed)
+                        {
+                            MatrixD rotationMat;
+                            if (!ComputedRotationMatricies.TryGetValue(def.RotateSpeed, out rotationMat))
+                            {
+                                rotationMat = MatrixD.CreateFromAxisAngle(mat.Forward, def.RotateSpeed * av.CurrentLifetime);
+                                ComputedRotationMatricies[def.RotateSpeed] = rotationMat;
+                            }
+
+                            mat = MatrixD.CreateWorld(mat.Translation, mat.Forward, Vector3D.TransformNormal(mat.Up, rotationMat));
+                        }
+
+                        bool isTri = def.P2 == def.P3;
+                        var P0 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P0, mat);
+                        var P1 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P1, mat);
+                        var P2 = av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P2, mat);
+                        var P3 = isTri ? P2 : av.ProjectileMatrix.Translation + Vector3D.TransformNormal(def.P3, mat);
+
+                        var midpoint = isTri ? (P0 + P1 + P2) / 3 : (P0 + P1 + P2 + P3) / 4;
+
+                        testSphere = new BoundingSphereD(midpoint, 1); // just want to test a point
+
+                        if (cam.IsInFrustum(ref testSphere))
+                        {
+                            var b = av.Billboards[i];
+                            b.Material = def.Material;
+                            b.LocalType = LocalTypeEnum.Custom;
+                            b.Position0 = P0;
+                            b.Position1 = P1;
+                            b.Position2 = P2;
+                            b.Position3 = P3;
+                            b.UVOffset = Vector2.Zero;
+                            b.UVSize = Vector2.One;
+                            b.DistanceSquared = Vector3.DistanceSquared(cam.Position, midpoint);
+                            b.Color = def.FactionColor == FactionColor.DontUse ? def.Color :
+                                def.FactionColor == FactionColor.Foreground ? av.Av.FgFactionColor : av.Av.BgFactionColor;
+                            b.Reflectivity = 0;
+                            b.CustomViewProjection = -1;
+                            b.ParentID = uint.MaxValue;
+                            b.ColorIntensity = 1f;
+                            b.SoftParticleDistanceScale = 1f;
+                            b.BlendType = BlendTypeEnum.Standard;
+
+                            BillBoardsToAdd.Add(b);
+                            advBillboardsDrawn++;
+                        }
+                    }
+                    ComputedRotationMatricies.Clear();
+                }
+            }
+            if (Session.I.Tick180)
+            {
+                Log.LineShortDate($"(ADV DRAWS) --------------- O:{advBillboardsOrphans} L:{advBillboardsLines} T:{advBillboardsTrails} B:{advBillboardsDrawn}", "stats");
+                _previousTrailCount = 0;
+                _shrinks = 0;
+            }
+            advBillboardsDrawn += advBillboardsLines + advBillboardsTrails + advBillboardsOrphans;
+            
             var requestCount = PreAddOneFrame.Count;
             if (requestCount > 0)
             {
-                if (requestCount > NearBillBoardLimit)
-                    NearBillBoardLimit = requestCount;
-                
-                BillBoardOneFrameQuads();
+                var coolDown = QuadCacheCoolDown[Session.I.Tick % QuadCacheCoolDown.Length];
+                for (int i = PreAddOneFrame.Count - 1; i >= 0; i--)
+                {
+                    var q = PreAddOneFrame[i];
+                    coolDown.Add(q);
+
+                    var b = q.BillBoard;
+
+                    if (q.Shot != null)
+                    {
+                        --q.Shot.ActiveBillBoards;
+                        q.Shot = null;
+                    }
+
+                    var cameraPosition = Session.I.CameraPos;
+                    if (!Vector3D.IsZero(cameraPosition - q.StartPos, 1E-06))
+                    {
+                        var polyLine = new MyPolyLineD
+                        {
+                            LineDirectionNormalized = (Vector3)q.Direction,
+                            Point0 = q.StartPos,
+                            Point1 = q.StartPos + q.Direction * q.Length,
+                            Thickness = q.Width
+                        };
+
+                        MyQuadD retQuad;
+                        MyUtils.GetPolyLineQuad(out retQuad, ref polyLine, cameraPosition);
+
+                        b.Material = q.Material;
+                        b.LocalType = LocalTypeEnum.Custom;
+                        b.Position0 = retQuad.Point0;
+                        b.Position1 = retQuad.Point1;
+                        b.Position2 = retQuad.Point2;
+                        b.Position3 = retQuad.Point3;
+                        b.UVOffset = Vector2.Zero;
+                        b.UVSize = Vector2.One;
+                        b.DistanceSquared = (float)Vector3D.DistanceSquared(cameraPosition, q.StartPos);
+                        b.Color = q.Color;
+                        b.Reflectivity = 0;
+                        b.CustomViewProjection = -1;
+                        b.ParentID = uint.MaxValue;
+                        b.ColorIntensity = 1f;
+                        b.SoftParticleDistanceScale = 1f;
+                        b.BlendType = BlendTypeEnum.Standard;
+
+                        BillBoardsToAdd.Add(b);
+                    }
+                }
+                PreAddOneFrame.Clear();
+            }
+            if (requestCount + advBillboardsDrawn > NearBillBoardLimit)
+                NearBillBoardLimit = requestCount + advBillboardsDrawn;
+
+            if (BillBoardsToAdd.Count > 0)
+            {
+                MyTransparentGeometry.AddBillboards(BillBoardsToAdd, false);
+                BillBoardsToAdd.Clear();
             }
         }
 
@@ -628,60 +1142,6 @@ namespace CoreSystems.Support
             Add,
             Update,
             Purge
-        }
-
-        internal void BillBoardOneFrameQuads()
-        {
-            var coolDown = QuadCacheCoolDown[Session.I.Tick % QuadCacheCoolDown.Length];
-            for (int i = PreAddOneFrame.Count - 1; i >= 0; i--)
-            {
-                var q = PreAddOneFrame[i];
-                coolDown.Add(q);
-
-                var b = q.BillBoard;
-
-                if (q.Shot != null) {
-                    --q.Shot.ActiveBillBoards;
-                    q.Shot = null;
-                }
-
-                var cameraPosition = Session.I.CameraPos;
-                if (!Vector3D.IsZero(cameraPosition - q.StartPos, 1E-06))
-                {
-                    var polyLine = new MyPolyLineD {
-                        LineDirectionNormalized = (Vector3)q.Direction,
-                        Point0 = q.StartPos,
-                        Point1 = q.StartPos + q.Direction * q.Length,
-                        Thickness = q.Width
-                    };
-
-                    MyQuadD retQuad;
-                    MyUtils.GetPolyLineQuad(out retQuad, ref polyLine, cameraPosition);
-
-                    b.Material = q.Material;
-                    b.LocalType = LocalTypeEnum.Custom;
-                    b.Position0 = retQuad.Point0;
-                    b.Position1 = retQuad.Point1;
-                    b.Position2 = retQuad.Point2;
-                    b.Position3 = retQuad.Point3;
-                    b.UVOffset = Vector2.Zero;
-                    b.UVSize = Vector2.One;
-                    b.DistanceSquared = (float)Vector3D.DistanceSquared(cameraPosition, q.StartPos);
-                    b.Color = q.Color;
-                    b.Reflectivity = 0;
-                    b.CustomViewProjection = -1;
-                    b.ParentID = uint.MaxValue;
-                    b.ColorIntensity = 1f;
-                    b.SoftParticleDistanceScale = 1f;
-                    b.BlendType = BlendTypeEnum.Standard;
-                    
-                    BillBoardsToAdd.Add(b);
-                }
-            }
-
-            MyTransparentGeometry.AddBillboards(BillBoardsToAdd, false);
-            BillBoardsToAdd.Clear();
-            PreAddOneFrame.Clear();
         }
 
 
@@ -1008,6 +1468,12 @@ namespace CoreSystems.Support
             for (int i = 0; i < quadCacheCollection.Count; i++)
                 QuadCachePool.Push(quadCacheCollection[i]);
             quadCacheCollection.Clear();
+
+            var lineCacheCollection = AdvBLineCacheCooldown[Session.I.Tick % AdvBLineCacheCooldown.Length];
+
+            for (int i = 0; i < lineCacheCollection.Count; i++)
+                AdvBLinesPool.Push(lineCacheCollection[i]);
+            lineCacheCollection.Clear();
         }
 
         internal void Clean()

--- a/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/RunAv.cs
@@ -527,8 +527,8 @@ namespace CoreSystems.Support
                     }
 
 
-                    line.Start = av.ProjectileMatrix.Translation + (MyUtils.IsZero(def.P0) ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(P0 + P0RndOffset, mat));
-                    line.End = av.ProjectileMatrix.Translation + (MyUtils.IsZero(def.P1) ? (Vector3D)P1RndOffset : Vector3D.TransformNormal(P1 + P1RndOffset, mat));
+                    line.Start = av.ProjectileMatrix.Translation + (def.TransformP0 ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(P0 + P0RndOffset, mat));
+                    line.End = av.ProjectileMatrix.Translation + (def.TransformP1 ? (Vector3D)P1RndOffset : Vector3D.TransformNormal(P1 + P1RndOffset, mat));
 
                     line.StartWidth = width;
                     line.StartColor = def.FactionColor == FactionColor.DontUse ? def.Color :
@@ -631,7 +631,7 @@ namespace CoreSystems.Support
                         P0RndOffset = new Vector3(a1sin * a2cos * r, a1sin * a2sin * r, a1cos * r);
                     }
 
-                    var p0Transformed = MyUtils.IsZero(def.P0) ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
+                    var p0Transformed = def.TransformP0 ? (Vector3D)P0RndOffset : Vector3D.TransformNormal(def.P0 + P0RndOffset, mat);
                     line.Start = av.ProjectileMatrix.Translation + p0Transformed;
 
                     if (trails.Count > 0)

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -896,6 +896,7 @@ namespace CoreSystems.Support
                 [ProtoMember(4)] internal AmmoParticleDef Particles;
                 [ProtoMember(5)] internal LineDef Lines;
                 [ProtoMember(6)] internal DecalDef Decals;
+                [ProtoMember(7)] internal AdvBillboardsDef AdvancedLines;
 
                 [ProtoContract]
                 public struct AmmoParticleDef
@@ -1007,6 +1008,77 @@ namespace CoreSystems.Support
                     {
                         [ProtoMember(1)] internal string HitMaterial; 
                         [ProtoMember(2)] internal string DecalMaterial;
+                    }
+                }
+
+                [ProtoContract]
+                public struct AdvBillboardsDef
+                {
+                    [ProtoMember(1)] internal bool Enable;
+                    [ProtoMember(2)] internal bool UseModelRotation;
+                    [ProtoMember(3)] internal Line[] AdvLines;
+                    [ProtoMember(4)] internal Trail[] AdvTrails;
+                    [ProtoMember(5)] internal Billboard[] Billboards;
+                    [ProtoContract]
+                    public struct Line
+                    {
+                        [ProtoMember(1)] public bool AlwaysDraw;
+                        [ProtoMember(2)] public bool OnlyDrawIfAccelerationAligned;
+                        [ProtoMember(3)] public bool WidthFade;
+                        [ProtoMember(4)] public bool ColorFade;
+                        [ProtoMember(5)] public bool LengthAffectedByAccelAlignment;
+                        [ProtoMember(6)] public bool AccelAccountForGrav;
+                        [ProtoMember(7)] public float AccelerationDotReq;
+                        [ProtoMember(8)] public float VelocityInheritence;
+                        [ProtoMember(9)] public uint TimeRendered;
+                        [ProtoMember(10)] public uint DelayBetweenSpawns;
+                        [ProtoMember(11)] public float P0RandomOffset;
+                        [ProtoMember(12)] public float P1RandomOffset;
+                        [ProtoMember(13)] public float Width;
+                        [ProtoMember(14)] public float RotateSpeed;
+                        [ProtoMember(15)] public float MaxViewDistance;
+                        [ProtoMember(16)] public float AccelerationSizeMultiplier;
+                        [ProtoMember(17)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                        [ProtoMember(18)] public LineDef.FactionColor FactionColor;
+                        [ProtoMember(19)] public string Material;
+                        [ProtoMember(20)] public Vector3 P0;
+                        [ProtoMember(21)] public Vector3 P1;
+                        [ProtoMember(22)] public Vector4 Color;
+                    }
+                    [ProtoContract]
+                    public struct Trail
+                    {
+                        [ProtoMember(1)] public bool WidthFade;
+                        [ProtoMember(2)] public bool ColorFade;
+                        [ProtoMember(3)] public bool AlwaysDraw;
+                        [ProtoMember(4)] public float VelocityInheritence;
+                        [ProtoMember(5)] public uint TimeRendered;
+                        [ProtoMember(6)] public uint DelayBetweenSpawns;
+                        [ProtoMember(7)] public float RotateSpeed;
+                        [ProtoMember(8)] public float P0RandomOffset;
+                        [ProtoMember(9)] public float Width;
+                        [ProtoMember(10)] public float MaxViewDistance;
+                        [ProtoMember(11)] public LineDef.FactionColor FactionColor;
+                        [ProtoMember(12)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                        [ProtoMember(13)] public string Material;
+                        [ProtoMember(14)] public Vector3 P0;
+                        [ProtoMember(15)] public Vector4 Color;
+                    }
+                    [ProtoContract]
+                    public struct Billboard
+                    {
+                        [ProtoMember(1)] public bool AlwaysDraw;
+                        [ProtoMember(2)] public bool ColorFade;
+                        [ProtoMember(3)] public float RotateSpeed;
+                        [ProtoMember(4)] public float MaxViewDistance;
+                        [ProtoMember(5)] public LineDef.FactionColor FactionColor;
+                        [ProtoMember(6)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                        [ProtoMember(7)] public string Material;
+                        [ProtoMember(8)] public Vector3 P0;
+                        [ProtoMember(9)] public Vector3 P1;
+                        [ProtoMember(10)] public Vector3 P2;
+                        [ProtoMember(11)] public Vector3 P3; // P2 == P3 for triangle
+                        [ProtoMember(12)] public Vector4 Color;
                     }
                 }
             }
@@ -1504,7 +1576,24 @@ namespace CoreSystems.Support
                         ForwardRelativeToShooter,
                         ForwardOriginDirection,
                     }
-
+                    public enum ModelRelativeTo
+                    {
+                        ModelNone = 0,
+                        ModelRelativeToGravity,
+                        ModelTargetDirection,
+                        ModelTargetPredictedDirection,
+                        ModelTargetVelocity,
+                        ModelStoredStartPosition,
+                        ModelStoredEndPosition,
+                        ModelStoredStartLocalPosition,
+                        ModelStoredEndLocalPosition,
+                        ModelRelativeToShooterForwards,
+                        ModelRelativeToShooterUp,
+                        ModelRelativeToShooterDirection,
+                        ModelOriginForwards,
+                        ModelOriginUp,
+                        ModelRelativeToOriginDirection,
+                    }
                     public enum RelativeTo
                     {
                         Origin,
@@ -1630,6 +1719,10 @@ namespace CoreSystems.Support
                     [ProtoMember(70)] internal Conditions EndCondition5;
                     [ProtoMember(71)] internal double End5Value;
                     [ProtoMember(72)] internal bool DockOnEnd;
+                    [ProtoMember(73)] internal bool AlternateModelForwardUp;
+                    [ProtoMember(74)] internal ModelRelativeTo ModelForwards;
+                    [ProtoMember(75)] internal ModelRelativeTo ModelUp;
+                    [ProtoMember(76)] internal bool ResetModelRotTimeOnTargetReset;
                 }
 
                 [ProtoContract]

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -1721,7 +1721,7 @@ namespace CoreSystems.Support
                     [ProtoMember(73)] internal bool AlternateModelForwardUp;
                     [ProtoMember(74)] internal ModelRelativeTo ModelForwards;
                     [ProtoMember(75)] internal ModelRelativeTo ModelUp;
-                    [ProtoMember(76)] internal bool ResetModelRotTimeOnTargetReset;
+                    [ProtoMember(76)] internal float ModelMaximumAngleToRotate;
                 }
 
                 [ProtoContract]

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -1593,6 +1593,7 @@ namespace CoreSystems.Support
                         ModelOriginForwards,
                         ModelOriginUp,
                         ModelRelativeToOriginDirection,
+                        ModelAcceleration,
                     }
                     public enum RelativeTo
                     {

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -1036,14 +1036,15 @@ namespace CoreSystems.Support
                         [ProtoMember(12)] public float P1RandomOffset;
                         [ProtoMember(13)] public float Width;
                         [ProtoMember(14)] public float RotateSpeed;
-                        [ProtoMember(15)] public float MaxViewDistance;
-                        [ProtoMember(16)] public float AccelerationSizeMultiplier;
-                        [ProtoMember(17)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                        [ProtoMember(18)] public LineDef.FactionColor FactionColor;
-                        [ProtoMember(19)] public string[] Materials;
-                        [ProtoMember(20)] public Vector3 P0;
-                        [ProtoMember(21)] public Vector3 P1;
-                        [ProtoMember(22)] public Vector4 Color;
+                        [ProtoMember(15)] public float MinViewDistance;
+                        [ProtoMember(16)] public float MaxViewDistance;
+                        [ProtoMember(17)] public float AccelerationSizeMultiplier;
+                        [ProtoMember(18)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                        [ProtoMember(19)] public LineDef.FactionColor FactionColor;
+                        [ProtoMember(20)] public string[] Materials;
+                        [ProtoMember(21)] public Vector3 P0;
+                        [ProtoMember(22)] public Vector3 P1;
+                        [ProtoMember(23)] public Vector4 Color;
                     }
                     [ProtoContract]
                     public struct Trail
@@ -1056,12 +1057,13 @@ namespace CoreSystems.Support
                         [ProtoMember(6)] public float RotateSpeed;
                         [ProtoMember(7)] public float P0RandomOffset;
                         [ProtoMember(8)] public float Width;
-                        [ProtoMember(9)] public float MaxViewDistance;
-                        [ProtoMember(10)] public LineDef.FactionColor FactionColor;
-                        [ProtoMember(11)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                        [ProtoMember(12)] public string[] Materials;
-                        [ProtoMember(13)] public Vector3 P0;
-                        [ProtoMember(14)] public Vector4 Color;
+                        [ProtoMember(9)] public float MinViewDistance;
+                        [ProtoMember(10)] public float MaxViewDistance;
+                        [ProtoMember(11)] public LineDef.FactionColor FactionColor;
+                        [ProtoMember(12)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                        [ProtoMember(13)] public string[] Materials;
+                        [ProtoMember(14)] public Vector3 P0;
+                        [ProtoMember(15)] public Vector4 Color;
                     }
                     [ProtoContract]
                     public struct Billboard
@@ -1069,15 +1071,16 @@ namespace CoreSystems.Support
                         [ProtoMember(1)] public bool AlwaysDraw;
                         [ProtoMember(2)] public bool ColorFade;
                         [ProtoMember(3)] public float RotateSpeed;
-                        [ProtoMember(4)] public float MaxViewDistance;
-                        [ProtoMember(5)] public LineDef.FactionColor FactionColor;
-                        [ProtoMember(6)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                        [ProtoMember(7)] public string[] Materials;
-                        [ProtoMember(8)] public Vector3 P0;
-                        [ProtoMember(9)] public Vector3 P1;
-                        [ProtoMember(10)] public Vector3 P2;
-                        [ProtoMember(11)] public Vector3 P3; // P2 == P3 for triangle
-                        [ProtoMember(12)] public Vector4 Color;
+                        [ProtoMember(4)] public float MinViewDistance;
+                        [ProtoMember(5)] public float MaxViewDistance;
+                        [ProtoMember(6)] public LineDef.FactionColor FactionColor;
+                        [ProtoMember(7)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                        [ProtoMember(8)] public string[] Materials;
+                        [ProtoMember(9)] public Vector3 P0;
+                        [ProtoMember(10)] public Vector3 P1;
+                        [ProtoMember(11)] public Vector3 P2;
+                        [ProtoMember(12)] public Vector3 P3; // P2 == P3 for triangle
+                        [ProtoMember(13)] public Vector4 Color;
                     }
                 }
             }

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -1040,7 +1040,7 @@ namespace CoreSystems.Support
                         [ProtoMember(16)] public float AccelerationSizeMultiplier;
                         [ProtoMember(17)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
                         [ProtoMember(18)] public LineDef.FactionColor FactionColor;
-                        [ProtoMember(19)] public string Material;
+                        [ProtoMember(19)] public string[] Materials;
                         [ProtoMember(20)] public Vector3 P0;
                         [ProtoMember(21)] public Vector3 P1;
                         [ProtoMember(22)] public Vector4 Color;
@@ -1051,18 +1051,17 @@ namespace CoreSystems.Support
                         [ProtoMember(1)] public bool WidthFade;
                         [ProtoMember(2)] public bool ColorFade;
                         [ProtoMember(3)] public bool AlwaysDraw;
-                        [ProtoMember(4)] public float VelocityInheritence;
-                        [ProtoMember(5)] public uint TimeRendered;
-                        [ProtoMember(6)] public uint DelayBetweenSpawns;
-                        [ProtoMember(7)] public float RotateSpeed;
-                        [ProtoMember(8)] public float P0RandomOffset;
-                        [ProtoMember(9)] public float Width;
-                        [ProtoMember(10)] public float MaxViewDistance;
-                        [ProtoMember(11)] public LineDef.FactionColor FactionColor;
-                        [ProtoMember(12)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                        [ProtoMember(13)] public string Material;
-                        [ProtoMember(14)] public Vector3 P0;
-                        [ProtoMember(15)] public Vector4 Color;
+                        [ProtoMember(4)] public uint TimeRendered;
+                        [ProtoMember(5)] public uint DelayBetweenSpawns;
+                        [ProtoMember(6)] public float RotateSpeed;
+                        [ProtoMember(7)] public float P0RandomOffset;
+                        [ProtoMember(8)] public float Width;
+                        [ProtoMember(9)] public float MaxViewDistance;
+                        [ProtoMember(10)] public LineDef.FactionColor FactionColor;
+                        [ProtoMember(11)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                        [ProtoMember(12)] public string[] Materials;
+                        [ProtoMember(13)] public Vector3 P0;
+                        [ProtoMember(14)] public Vector4 Color;
                     }
                     [ProtoContract]
                     public struct Billboard
@@ -1073,7 +1072,7 @@ namespace CoreSystems.Support
                         [ProtoMember(4)] public float MaxViewDistance;
                         [ProtoMember(5)] public LineDef.FactionColor FactionColor;
                         [ProtoMember(6)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                        [ProtoMember(7)] public string Material;
+                        [ProtoMember(7)] public string[] Materials;
                         [ProtoMember(8)] public Vector3 P0;
                         [ProtoMember(9)] public Vector3 P1;
                         [ProtoMember(10)] public Vector3 P2;

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -1068,19 +1068,17 @@ namespace CoreSystems.Support
                     [ProtoContract]
                     public struct Billboard
                     {
-                        [ProtoMember(1)] public bool AlwaysDraw;
-                        [ProtoMember(2)] public bool ColorFade;
-                        [ProtoMember(3)] public float RotateSpeed;
-                        [ProtoMember(4)] public float MinViewDistance;
-                        [ProtoMember(5)] public float MaxViewDistance;
-                        [ProtoMember(6)] public LineDef.FactionColor FactionColor;
-                        [ProtoMember(7)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-                        [ProtoMember(8)] public string[] Materials;
-                        [ProtoMember(9)] public Vector3 P0;
-                        [ProtoMember(10)] public Vector3 P1;
-                        [ProtoMember(11)] public Vector3 P2;
-                        [ProtoMember(12)] public Vector3 P3; // P2 == P3 for triangle
-                        [ProtoMember(13)] public Vector4 Color;
+                        [ProtoMember(1)] public float RotateSpeed;
+                        [ProtoMember(2)] public float MinViewDistance;
+                        [ProtoMember(3)] public float MaxViewDistance;
+                        [ProtoMember(4)] public LineDef.FactionColor FactionColor;
+                        [ProtoMember(5)] public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+                        [ProtoMember(6)] public string[] Materials;
+                        [ProtoMember(7)] public Vector3 P0;
+                        [ProtoMember(8)] public Vector3 P1;
+                        [ProtoMember(9)] public Vector3 P2;
+                        [ProtoMember(10)] public Vector3 P3; // P2 == P3 for triangle
+                        [ProtoMember(11)] public Vector4 Color;
                     }
                 }
             }

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -1045,6 +1045,7 @@ namespace CoreSystems.Support
                         [ProtoMember(21)] public Vector3 P0;
                         [ProtoMember(22)] public Vector3 P1;
                         [ProtoMember(23)] public Vector4 Color;
+                        [ProtoMember(24)] public uint DelayBetweenSpawnsOffset;
                     }
                     [ProtoContract]
                     public struct Trail
@@ -1064,6 +1065,7 @@ namespace CoreSystems.Support
                         [ProtoMember(13)] public string[] Materials;
                         [ProtoMember(14)] public Vector3 P0;
                         [ProtoMember(15)] public Vector4 Color;
+                        [ProtoMember(16)] public uint DelayBetweenSpawnsOffset;
                     }
                     [ProtoContract]
                     public struct Billboard
@@ -1079,6 +1081,8 @@ namespace CoreSystems.Support
                         [ProtoMember(9)] public Vector3 P2;
                         [ProtoMember(10)] public Vector3 P3; // P2 == P3 for triangle
                         [ProtoMember(11)] public Vector4 Color;
+                        [ProtoMember(12)] public uint DelayBetweenSpawns;
+                        [ProtoMember(13)] public uint DelayBetweenSpawnsOffset;
                     }
                 }
             }

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -653,6 +653,8 @@ namespace CoreSystems.Support
                         AccelerationSizeMultiplier = n.AccelerationSizeMultiplier,
                         LengthAffectedByAccelAlignment = n.LengthAffectedByAccelAlignment,
                         AccelAccountForGrav = n.AccelAccountForGrav,
+                        TransformP0 = !MyUtils.IsZero(n.P0),
+                        TransformP1 = !MyUtils.IsZero(n.P1),
                     };
                     if (n.Materials != null)
                         for (int j = 0; j < n.Materials.Length; j++)
@@ -685,6 +687,7 @@ namespace CoreSystems.Support
                         RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
                         MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
                         MinViewDistanceSq = n.MinViewDistance * n.MinViewDistance,
+                        TransformP0 = !MyUtils.IsZero(n.P0),
                     };
                     if (n.Materials != null)
                         for (int j = 0; j < n.Materials.Length; j++)
@@ -2332,6 +2335,8 @@ namespace CoreSystems.Support
             public bool OnlyDrawIfAccelerationAligned;
             public bool LengthAffectedByAccelAlignment;
             public bool AccelAccountForGrav;
+            public bool TransformP0;
+            public bool TransformP1;
             public uint TimeRendered;
             public uint DelayBetweenSpawns;
             public float P0RandomOffset;
@@ -2357,6 +2362,7 @@ namespace CoreSystems.Support
             public bool ColorFade;
             public bool AlwaysDraw;
             public bool HasRotateSpeed;
+            public bool TransformP0;
             public uint TimeRendered;
             public uint DelayBetweenSpawns;
             public uint NumberOfTimesToRepeat;

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -707,6 +707,7 @@ namespace CoreSystems.Support
                         P1 = n.P1,
                         P2 = n.P2,
                         P3 = n.P3,
+                        IsTri = n.P2 == n.P3,
                         Color = n.Color.ToLinearRGB(),
                         HasRotateSpeed = n.RotateSpeed != 0 && (n.P0.X != 0 || n.P0.Y != 0 || n.P1.X != 0 || n.P1.Y != 0 || n.P2.X != 0 || n.P2.Y != 0 || n.P3.X != 0 || n.P3.Y != 0), // if theres nothing to rotate then don't
                         RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
@@ -2337,6 +2338,7 @@ namespace CoreSystems.Support
             public float Width;
             public float RotateSpeed;
             public float VelocityInheritence;
+            public float MinViewDistanceSq;
             public float MaxViewDistanceSq;
             public float AccelerationDotReq;
             public float AccelerationSizeMultiplier;
@@ -2360,6 +2362,7 @@ namespace CoreSystems.Support
             public float P0RandomOffset;
             public float Width;
             public float RotateSpeed;
+            public float MinViewDistanceSq;
             public float MaxViewDistanceSq;
             public MyStringId[] Materials;
             public FactionColor FactionColor;
@@ -2373,7 +2376,9 @@ namespace CoreSystems.Support
             public bool AlwaysDraw;
             public bool ColorFade;
             public bool HasRotateSpeed;
+            public bool IsTri;
             public float RotateSpeed;
+            public float MinViewDistanceSq;
             public float MaxViewDistanceSq;
             public FactionColor FactionColor;
             public VRageRender.MyBillboard.BlendTypeEnum BlendType;

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -655,6 +655,7 @@ namespace CoreSystems.Support
                         AccelAccountForGrav = n.AccelAccountForGrav,
                         TransformP0 = !MyUtils.IsZero(n.P0),
                         TransformP1 = !MyUtils.IsZero(n.P1),
+                        DelayBetweenSpawnsOffset = n.DelayBetweenSpawnsOffset,
                     };
                     if (n.Materials != null)
                         for (int j = 0; j < n.Materials.Length; j++)
@@ -688,6 +689,7 @@ namespace CoreSystems.Support
                         MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
                         MinViewDistanceSq = n.MinViewDistance * n.MinViewDistance,
                         TransformP0 = !MyUtils.IsZero(n.P0),
+                        DelayBetweenSpawnsOffset = n.DelayBetweenSpawnsOffset,
                     };
                     if (n.Materials != null)
                         for (int j = 0; j < n.Materials.Length; j++)
@@ -716,7 +718,10 @@ namespace CoreSystems.Support
                         RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
                         MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
                         MinViewDistanceSq = n.MinViewDistance * n.MinViewDistance,
+                        DelayBetweenSpawns = n.DelayBetweenSpawns,
+                        DelayBetweenSpawnsOffset = n .DelayBetweenSpawnsOffset,
                     };
+
 
                     if (n.Materials != null)
                         for (int j = 0; j < n.Materials.Length; j++)
@@ -2344,6 +2349,7 @@ namespace CoreSystems.Support
             public bool TransformP1;
             public uint TimeRendered;
             public uint DelayBetweenSpawns;
+            public uint DelayBetweenSpawnsOffset;
             public float P0RandomOffset;
             public float P1RandomOffset;
             public float Width;
@@ -2370,6 +2376,7 @@ namespace CoreSystems.Support
             public bool TransformP0;
             public uint TimeRendered;
             public uint DelayBetweenSpawns;
+            public uint DelayBetweenSpawnsOffset;
             public uint NumberOfTimesToRepeat;
             public float P0RandomOffset;
             public float Width;
@@ -2387,6 +2394,8 @@ namespace CoreSystems.Support
         {
             public bool HasRotateSpeed;
             public bool IsTri;
+            public uint DelayBetweenSpawns;
+            public uint DelayBetweenSpawnsOffset;
             public float RotateSpeed;
             public float MinViewDistanceSq;
             public float MaxViewDistanceSq;

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -641,7 +641,7 @@ namespace CoreSystems.Support
                         Width = n.Width,
                         BlendType = n.BlendType,
                         FactionColor = n.FactionColor,
-                        Material = MyStringId.GetOrCompute(n.Material),
+                        Materials = new MyStringId[n.Materials == null ? 0 : n.Materials.Length],
                         P0 = n.P0,
                         P1 = n.P1,
                         Color = n.Color.ToLinearRGB(),
@@ -653,6 +653,9 @@ namespace CoreSystems.Support
                         LengthAffectedByAccelAlignment = n.LengthAffectedByAccelAlignment,
                         AccelAccountForGrav = n.AccelAccountForGrav,
                     };
+                    if (n.Materials != null)
+                        for (int j = 0; j < n.Materials.Length; j++)
+                            billboards.Lines[i].Materials[j] = MyStringId.GetOrCompute(n.Materials[j]);
                 }
             }
 
@@ -666,7 +669,6 @@ namespace CoreSystems.Support
                     billboards.Trails[i] = new AdvBillboards.TrailConstants
                     {
                         AlwaysDraw = n.AlwaysDraw,
-                        VelocityInheritence = n.VelocityInheritence,
                         WidthFade = n.WidthFade && t > 1,
                         ColorFade = n.ColorFade && t > 1,
                         TimeRendered = t,
@@ -675,13 +677,16 @@ namespace CoreSystems.Support
                         Width = n.Width,
                         BlendType = n.BlendType,
                         FactionColor = n.FactionColor,
-                        Material = MyStringId.GetOrCompute(n.Material),
+                        Materials = new MyStringId[n.Materials == null ? 0 : n.Materials.Length],
                         P0 = n.P0,
                         Color = n.Color.ToLinearRGB(),
                         HasRotateSpeed = n.RotateSpeed != 0 && (n.P0.X != 0 || n.P0.Y != 0), // if theres nothing to rotate then don't
                         RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
                         MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
                     };
+                    if (n.Materials != null)
+                        for (int j = 0; j < n.Materials.Length; j++)
+                            billboards.Trails[i].Materials[j] = MyStringId.GetOrCompute(n.Materials[j]);
                 }
             }
 
@@ -697,7 +702,7 @@ namespace CoreSystems.Support
                         ColorFade = n.ColorFade,
                         BlendType = n.BlendType,
                         FactionColor = n.FactionColor,
-                        Material = MyStringId.GetOrCompute(n.Material),
+                        Materials = new MyStringId[n.Materials == null ? 0 : n.Materials.Length],
                         P0 = n.P0,
                         P1 = n.P1,
                         P2 = n.P2,
@@ -707,6 +712,10 @@ namespace CoreSystems.Support
                         RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
                         MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
                     };
+
+                    if (n.Materials != null)
+                        for (int j = 0; j < n.Materials.Length; j++)
+                            billboards.Billboards[i].Materials[j] = MyStringId.GetOrCompute(n.Materials[j]);
                 }
             }
 
@@ -2332,7 +2341,7 @@ namespace CoreSystems.Support
             public float AccelerationSizeMultiplier;
             public VRageRender.MyBillboard.BlendTypeEnum BlendType;
             public FactionColor FactionColor;
-            public MyStringId Material;
+            public MyStringId[] Materials;
             public Vector3 P0;
             public Vector3 P1;
             public Vector4 Color;
@@ -2350,9 +2359,8 @@ namespace CoreSystems.Support
             public float P0RandomOffset;
             public float Width;
             public float RotateSpeed;
-            public float VelocityInheritence;
             public float MaxViewDistanceSq;
-            public MyStringId Material;
+            public MyStringId[] Materials;
             public FactionColor FactionColor;
             public VRageRender.MyBillboard.BlendTypeEnum BlendType;
             public Vector3 P0;
@@ -2368,7 +2376,7 @@ namespace CoreSystems.Support
             public float MaxViewDistanceSq;
             public FactionColor FactionColor;
             public VRageRender.MyBillboard.BlendTypeEnum BlendType;
-            public MyStringId Material;
+            public MyStringId[] Materials;
             public Vector3 P0;
             public Vector3 P1;
             public Vector3 P2;

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -2086,6 +2086,8 @@ namespace CoreSystems.Support
         public readonly double LeadDistance;
         public readonly double AccelMulti;
         public readonly double SpeedCapMulti;
+        public readonly double TotalAccelMultiSq;
+        public readonly double DeAccelMulti;
 
         public readonly double Start1Value;
         public readonly double Start2Value;
@@ -2197,6 +2199,9 @@ namespace CoreSystems.Support
 
             ModFutureStep = futureStepLimit;
             GetOperators(def, out StartAnd, out EndAnd);
+
+            DeAccelMulti = def.DeAccelMulti != 0 ? def.DeAccelMulti : 1d;
+            TotalAccelMultiSq = def.TotalAccelMulti > 0 ? def.TotalAccelMulti * def.TotalAccelMulti : 1d;
         }
 
         private static void GetOperators(TrajectoryDef.ApproachDef def, out bool startAnd, out bool endAnd)

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -648,6 +648,7 @@ namespace CoreSystems.Support
                         HasRotateSpeed = n.RotateSpeed != 0 && (n.P0.X != 0 || n.P0.Y != 0 || n.P1.X != 0 || n.P1.Y != 0), // if theres nothing to rotate then don't
                         RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
                         MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
+                        MinViewDistanceSq = n.MinViewDistance * n.MinViewDistance,
                         AccelerationDotReq = n.AccelerationDotReq,
                         AccelerationSizeMultiplier = n.AccelerationSizeMultiplier,
                         LengthAffectedByAccelAlignment = n.LengthAffectedByAccelAlignment,
@@ -683,6 +684,7 @@ namespace CoreSystems.Support
                         HasRotateSpeed = n.RotateSpeed != 0 && (n.P0.X != 0 || n.P0.Y != 0), // if theres nothing to rotate then don't
                         RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
                         MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
+                        MinViewDistanceSq = n.MinViewDistance * n.MinViewDistance,
                     };
                     if (n.Materials != null)
                         for (int j = 0; j < n.Materials.Length; j++)
@@ -710,6 +712,7 @@ namespace CoreSystems.Support
                         HasRotateSpeed = n.RotateSpeed != 0 && (n.P0.X != 0 || n.P0.Y != 0 || n.P1.X != 0 || n.P1.Y != 0 || n.P2.X != 0 || n.P2.Y != 0 || n.P3.X != 0 || n.P3.Y != 0), // if theres nothing to rotate then don't
                         RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
                         MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
+                        MinViewDistanceSq = n.MinViewDistance * n.MinViewDistance,
                     };
 
                     if (n.Materials != null)

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -698,8 +698,6 @@ namespace CoreSystems.Support
                     var n = advLines.Billboards[i];
                     billboards.Billboards[i] = new AdvBillboards.BillboardConstants
                     {
-                        AlwaysDraw = n.AlwaysDraw,
-                        ColorFade = n.ColorFade,
                         BlendType = n.BlendType,
                         FactionColor = n.FactionColor,
                         Materials = new MyStringId[n.Materials == null ? 0 : n.Materials.Length],
@@ -2373,8 +2371,6 @@ namespace CoreSystems.Support
 
         public struct BillboardConstants
         {
-            public bool AlwaysDraw;
-            public bool ColorFade;
             public bool HasRotateSpeed;
             public bool IsTri;
             public float RotateSpeed;

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -2071,7 +2071,6 @@ namespace CoreSystems.Support
         public readonly bool SelfPhasing;
         public readonly bool SwapNavigationType;
         public readonly bool AlternateModelForwardUp;
-        public readonly bool ResetModelRotTimeOnTargetReset;
         public readonly double OrbitRadius;
         public readonly double AngleOffset;
         public readonly double DesiredElevation;
@@ -2096,6 +2095,8 @@ namespace CoreSystems.Support
         public readonly int StoredStartId;
         public readonly int StoredEndId;
         public readonly int ModelRotateTime;
+
+        public readonly float ModelMaximumAngleToRotate;
         public ApproachConstants(WeaponSystem.AmmoType ammo, int index, WeaponDefinition wDef)
         {
             var def = ammo.AmmoDef.Trajectory.Approaches[index];
@@ -2112,7 +2113,7 @@ namespace CoreSystems.Support
             LeadRotateElevatePositionC = def.LeadRotateElevatePositionC;
             NoElevationLead = def.NoElevationLead;
             IgnoreAntiSmart = def.IgnoreAntiSmart;
-            ModelRotate = def.ModelRotateTime > 0;
+            ModelRotate = def.ModelRotateTime > 0 || def.ModelMaximumAngleToRotate > 0;
             ToggleIngoreVoxels = def.ToggleIngoreVoxels;
             SelfAvoidance = def.SelfAvoidance;
             TargetAvoidance = def.TargetAvoidance;
@@ -2165,7 +2166,7 @@ namespace CoreSystems.Support
             SpeedCapMulti = def.SpeedCapMulti;
 
             AlternateModelForwardUp = def.AlternateModelForwardUp;
-            ResetModelRotTimeOnTargetReset = def.ResetModelRotTimeOnTargetReset;
+            ModelMaximumAngleToRotate = def.ModelMaximumAngleToRotate <= 0 ? 0 : MathHelper.ToRadians(def.ModelMaximumAngleToRotate) / 60f;
 
             ElevationTolerance = def.ElevationTolerance;
             if (AlternateModel)

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -17,6 +17,7 @@ using static CoreSystems.Support.WeaponDefinition.AmmoDef.DamageScaleDef;
 using static CoreSystems.Support.WeaponDefinition.AmmoDef.FragmentDef.TimedSpawnDef;
 using static CoreSystems.Support.WeaponDefinition.HardPointDef;
 using static CoreSystems.Support.WeaponDefinition.AmmoDef.GraphicDef.LineDef;
+using static CoreSystems.Support.WeaponDefinition.AmmoDef.GraphicDef.LineDef.FactionColor;
 using static CoreSystems.Settings.CoreSettings.ServerSettings;
 using static CoreSystems.Session;
 
@@ -57,6 +58,7 @@ namespace CoreSystems.Support
         public readonly XorShiftRandom Random;
         public readonly AmmoOverride Overrides;
         public readonly HashSet<uint> ProjectileTags;
+        public readonly AdvBillboards AdvBillboardSettings;
 
         public readonly MyStringId[] TracerTextures;
         public readonly MyStringId[] TrailTextures;
@@ -170,6 +172,7 @@ namespace CoreSystems.Support
         public readonly bool WaterHitParticleNoCull;
         public readonly bool VoxelHitParticleNoCull;
         public readonly bool DrawLine;
+        public readonly bool DrawAdvBillboards;
         public readonly bool Ewar;
         public readonly bool NonAntiSmartEwar;
         public readonly bool TargetOffSet;
@@ -595,8 +598,130 @@ namespace CoreSystems.Support
             ProjectilesFirst = system.ProjectilesFirst;
 
             PFlags(ammo, out ProjectileTags);
-
+            ComputeAdvBillboards(ammo.AmmoDef, out AdvBillboardSettings, out DrawAdvBillboards);
             PreComputedMath = new PreComputedMath(ammo, this);
+        }
+
+        internal void ComputeAdvBillboards(AmmoDef ammo, out AdvBillboards billboards, out bool DrawAdvBillboards)
+        {
+            const double DEG_PER_SEC_TO_RAD_PER_TICK = (Math.PI / 180d) / 60d;
+
+            billboards = null;
+            var advLines = ammo.AmmoGraphics.AdvancedLines;
+            DrawAdvBillboards = advLines.Enable && !ammo.Beams.Enable;
+
+            if (!DrawAdvBillboards)
+                return;
+
+            
+
+            billboards = new AdvBillboards()
+            {
+                UseModelRotation = ammo.AmmoGraphics.AdvancedLines.UseModelRotation,
+            };
+
+            if (advLines.AdvLines != null && advLines.AdvLines.Length > 0)
+            {
+                billboards.Lines = new AdvBillboards.LineConstants[advLines.AdvLines.Length];
+                for (int i = 0; i < advLines.AdvLines.Length; i++)
+                {
+                    var n = advLines.AdvLines[i];
+                    var t = n.TimeRendered <= 0 ? 1 : n.TimeRendered;
+                    billboards.Lines[i] = new AdvBillboards.LineConstants
+                    {
+                        AlwaysDraw = n.AlwaysDraw,
+                        VelocityInheritence = n.VelocityInheritence,
+                        OnlyDrawIfAccelerationAligned = n.OnlyDrawIfAccelerationAligned,
+                        WidthFade = n.WidthFade && t > 1,
+                        ColorFade = n.ColorFade && t > 1,
+                        TimeRendered = t,
+                        DelayBetweenSpawns = n.DelayBetweenSpawns,
+                        P0RandomOffset = n.P0RandomOffset,
+                        P1RandomOffset = n.P1RandomOffset,
+                        Width = n.Width,
+                        BlendType = n.BlendType,
+                        FactionColor = n.FactionColor,
+                        Material = MyStringId.GetOrCompute(n.Material),
+                        P0 = n.P0,
+                        P1 = n.P1,
+                        Color = n.Color.ToLinearRGB(),
+                        HasRotateSpeed = n.RotateSpeed != 0 && (n.P0.X != 0 || n.P0.Y != 0 || n.P1.X != 0 || n.P1.Y != 0), // if theres nothing to rotate then don't
+                        RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
+                        MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
+                        AccelerationDotReq = n.AccelerationDotReq,
+                        AccelerationSizeMultiplier = n.AccelerationSizeMultiplier,
+                        LengthAffectedByAccelAlignment = n.LengthAffectedByAccelAlignment,
+                        AccelAccountForGrav = n.AccelAccountForGrav,
+                    };
+                }
+            }
+
+            if (advLines.AdvTrails != null && advLines.AdvTrails.Length > 0)
+            {
+                billboards.Trails = new AdvBillboards.TrailConstants[advLines.AdvTrails.Length];
+                for (int i = 0; i < advLines.AdvTrails.Length; i++)
+                {
+                    var n = advLines.AdvTrails[i];
+                    var t = n.TimeRendered == 0 ? 1 : n.TimeRendered;
+                    billboards.Trails[i] = new AdvBillboards.TrailConstants
+                    {
+                        AlwaysDraw = n.AlwaysDraw,
+                        VelocityInheritence = n.VelocityInheritence,
+                        WidthFade = n.WidthFade && t > 1,
+                        ColorFade = n.ColorFade && t > 1,
+                        TimeRendered = t,
+                        DelayBetweenSpawns = n.DelayBetweenSpawns,
+                        P0RandomOffset = n.P0RandomOffset,
+                        Width = n.Width,
+                        BlendType = n.BlendType,
+                        FactionColor = n.FactionColor,
+                        Material = MyStringId.GetOrCompute(n.Material),
+                        P0 = n.P0,
+                        Color = n.Color.ToLinearRGB(),
+                        HasRotateSpeed = n.RotateSpeed != 0 && (n.P0.X != 0 || n.P0.Y != 0), // if theres nothing to rotate then don't
+                        RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
+                        MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
+                    };
+                }
+            }
+
+            if (advLines.Billboards != null && advLines.Billboards.Length > 0)
+            {
+                billboards.Billboards = new AdvBillboards.BillboardConstants[advLines.Billboards.Length];
+                for (int i = 0; i < advLines.Billboards.Length; i++)
+                {
+                    var n = advLines.Billboards[i];
+                    billboards.Billboards[i] = new AdvBillboards.BillboardConstants
+                    {
+                        AlwaysDraw = n.AlwaysDraw,
+                        ColorFade = n.ColorFade,
+                        BlendType = n.BlendType,
+                        FactionColor = n.FactionColor,
+                        Material = MyStringId.GetOrCompute(n.Material),
+                        P0 = n.P0,
+                        P1 = n.P1,
+                        P2 = n.P2,
+                        P3 = n.P3,
+                        Color = n.Color.ToLinearRGB(),
+                        HasRotateSpeed = n.RotateSpeed != 0 && (n.P0.X != 0 || n.P0.Y != 0 || n.P1.X != 0 || n.P1.Y != 0 || n.P2.X != 0 || n.P2.Y != 0 || n.P3.X != 0 || n.P3.Y != 0), // if theres nothing to rotate then don't
+                        RotateSpeed = (float)(n.RotateSpeed * DEG_PER_SEC_TO_RAD_PER_TICK),
+                        MaxViewDistanceSq = n.MaxViewDistance * n.MaxViewDistance,
+                    };
+                }
+            }
+
+            if (billboards.Lines == null)
+            {
+                billboards.Lines = new AdvBillboards.LineConstants[0];
+            }
+            if (billboards.Trails == null)
+            {
+                billboards.Trails = new AdvBillboards.TrailConstants[0];
+            }
+            if (billboards.Billboards == null)
+            {
+                billboards.Billboards = new AdvBillboards.BillboardConstants[0];
+            }
         }
 
         internal void Purge()
@@ -1915,6 +2040,8 @@ namespace CoreSystems.Support
         public readonly TrajectoryDef.ApproachDef.Conditions EndCon3;
         public readonly TrajectoryDef.ApproachDef.Conditions EndCon4;
         public readonly TrajectoryDef.ApproachDef.Conditions EndCon5;
+        public readonly TrajectoryDef.ApproachDef.ModelRelativeTo ModelUp;
+        public readonly TrajectoryDef.ApproachDef.ModelRelativeTo ModelFwds;
         public readonly bool AdjustForward;
         public readonly bool AdjustUp;
         public readonly bool DisableAvoidance;
@@ -1934,6 +2061,8 @@ namespace CoreSystems.Support
         public readonly bool TargetAvoidance;
         public readonly bool SelfPhasing;
         public readonly bool SwapNavigationType;
+        public readonly bool AlternateModelForwardUp;
+        public readonly bool ResetModelRotTimeOnTargetReset;
         public readonly double OrbitRadius;
         public readonly double AngleOffset;
         public readonly double DesiredElevation;
@@ -1984,6 +2113,8 @@ namespace CoreSystems.Support
             ElevationRelatveToC = def.ElevationRelativeToC;
             Forward = def.Forward;
             Up = def.Up;
+            ModelFwds = def.ModelForwards;
+            ModelUp = def.ModelUp;
             PositionB = def.PositionB;
             PositionC = def.PositionC;
             Elevation = def.Elevation;
@@ -2023,6 +2154,9 @@ namespace CoreSystems.Support
             LeadDistance = def.LeadDistance;
             AccelMulti = def.AccelMulti;
             SpeedCapMulti = def.SpeedCapMulti;
+
+            AlternateModelForwardUp = def.AlternateModelForwardUp;
+            ResetModelRotTimeOnTargetReset = def.ResetModelRotTimeOnTargetReset;
 
             ElevationTolerance = def.ElevationTolerance;
             if (AlternateModel)
@@ -2168,7 +2302,79 @@ namespace CoreSystems.Support
             myEntity.InScene = false;
             myEntity.Render.RemoveRenderObjects();
         }
+    }
 
+    public class AdvBillboards
+    {
+        public bool UseModelRotation;
+        public LineConstants[] Lines;
+        public TrailConstants[] Trails;
+        public BillboardConstants[] Billboards;
+
+        public struct LineConstants
+        {
+            public bool AlwaysDraw;
+            public bool WidthFade;
+            public bool ColorFade;
+            public bool HasRotateSpeed;
+            public bool OnlyDrawIfAccelerationAligned;
+            public bool LengthAffectedByAccelAlignment;
+            public bool AccelAccountForGrav;
+            public uint TimeRendered;
+            public uint DelayBetweenSpawns;
+            public float P0RandomOffset;
+            public float P1RandomOffset;
+            public float Width;
+            public float RotateSpeed;
+            public float VelocityInheritence;
+            public float MaxViewDistanceSq;
+            public float AccelerationDotReq;
+            public float AccelerationSizeMultiplier;
+            public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+            public FactionColor FactionColor;
+            public MyStringId Material;
+            public Vector3 P0;
+            public Vector3 P1;
+            public Vector4 Color;
+        }
+
+        public struct TrailConstants
+        {
+            public bool WidthFade;
+            public bool ColorFade;
+            public bool AlwaysDraw;
+            public bool HasRotateSpeed;
+            public uint TimeRendered;
+            public uint DelayBetweenSpawns;
+            public uint NumberOfTimesToRepeat;
+            public float P0RandomOffset;
+            public float Width;
+            public float RotateSpeed;
+            public float VelocityInheritence;
+            public float MaxViewDistanceSq;
+            public MyStringId Material;
+            public FactionColor FactionColor;
+            public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+            public Vector3 P0;
+            public Vector4 Color;
+        }
+
+        public struct BillboardConstants
+        {
+            public bool AlwaysDraw;
+            public bool ColorFade;
+            public bool HasRotateSpeed;
+            public float RotateSpeed;
+            public float MaxViewDistanceSq;
+            public FactionColor FactionColor;
+            public VRageRender.MyBillboard.BlendTypeEnum BlendType;
+            public MyStringId Material;
+            public Vector3 P0;
+            public Vector3 P1;
+            public Vector3 P2;
+            public Vector3 P3;
+            public Vector4 Color;
+        }
     }
 
     public class PreComputedMath

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/PacketTypes.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/PacketTypes.cs
@@ -123,8 +123,8 @@ namespace CoreSystems
     public class Packet
     {
         [ProtoMember(1)] internal long EntityId;
-        [ProtoMember(2)] internal ulong SenderId;
-        [ProtoMember(3)] internal PacketType PType;
+        [ProtoIgnore] internal ulong SenderId;
+        [ProtoMember(2)] internal PacketType PType;
 
         public virtual void CleanUp()
         {
@@ -181,30 +181,30 @@ namespace CoreSystems
         /// <summary>
         ///     The EntityId of the grid (directly taken from the <see cref="Target.TargetObject"/> when it is an entity.
         /// </summary>
-        [ProtoMember(2)] public long EntityId;
+        [ProtoMember(2)] public long? EntityId;
         /// <summary>
         ///     The NetId of the projectile (directly taken from the <see cref="Target.TargetObject"/> when it is an AdvSync projectile.
         /// </summary>
-        [ProtoMember(3)] public ulong ProjectileNetId;
+        [ProtoMember(3)] public ulong? ProjectileNetId;
         /// <summary>
         ///     The grid (actually, mik painted a suit once?) the fake target is attached to:
         /// </summary>
-        [ProtoMember(4)] public long FakeEntityId;
+        [ProtoMember(4)] public long? FakeEntityId;
         /// <summary>
         ///     The targeted point in the entity's local frame:
         /// </summary>
-        [ProtoMember(5)] public Vector3D FakeLocalPos;
+        [ProtoMember(5)] public Vector3? FakeLocalPos;
         /// <summary>
         ///     The current position of the target in the world frame:
         /// </summary>
-        [ProtoMember(6)] public Vector3D FakeWorldPos;
+        [ProtoMember(6)] public Vector3D? FakeWorldPos;
         /// <summary>
         ///     The fake target type. Must be <see cref="AdvSyncFakeType.Manual"/> or <see cref="AdvSyncFakeType.Painted"/>.
         /// </summary>
-        [ProtoMember(7)] public AdvSyncFakeType FakeType;
+        [ProtoMember(7)] public AdvSyncFakeType? FakeType;
         
-        [ProtoMember(8)] public Vector3D LinearVelocity;
-        [ProtoMember(9)] public Vector3D Acceleration;
+        [ProtoMember(8)] public Vector3? LinearVelocity;
+        [ProtoMember(9)] public Vector3? Acceleration;
 
         /// <summary>
         ///     Extracts target info from a projectile's current state.
@@ -300,11 +300,11 @@ namespace CoreSystems
                 case AdvTargetType.Entity:
                 {
                     MyEntity targetEnt;
-                    if (MyEntities.TryGetEntityById(EntityId, out targetEnt))
+                    if (MyEntities.TryGetEntityById(EntityId ?? 0, out targetEnt))
                     {
                         target.TargetObject = targetEnt;
                         target.TargetState = Target.TargetStates.IsEntity;
-                        target.TargetPos = FakeWorldPos;
+                        target.TargetPos = FakeWorldPos ?? Vector3D.Zero;
                         return true;
                     }
 
@@ -314,7 +314,7 @@ namespace CoreSystems
                 case AdvTargetType.Projectile:
                 {
                     Projectile targetPro;
-                    if (Session.I.ProjectilesByNetId.TryGetValue(ProjectileNetId, out targetPro))
+                    if (Session.I.ProjectilesByNetId.TryGetValue(ProjectileNetId ?? 0, out targetPro))
                     {
                         target.TargetObject = targetPro;
                         target.TargetState = Target.TargetStates.IsProjectile;
@@ -330,14 +330,14 @@ namespace CoreSystems
                 {
                     target.TargetObject = null;
                     target.TargetState = Target.TargetStates.IsFake;
-                    target.TargetPos = FakeWorldPos;
+                    target.TargetPos = FakeWorldPos ?? Vector3D.Zero;
 
                     if (storage.DummyTargets == null)
                     {
                         storage.DummyTargets = new Ai.FakeTargets();
                     }
 
-                    if (FakeType == AdvSyncFakeType.Invalid || (byte)FakeType > (byte)AdvSyncFakeType.Painted)
+                    if (FakeType == null || FakeType == AdvSyncFakeType.Invalid || (byte)FakeType > (byte)AdvSyncFakeType.Painted)
                     {
                         DebugLog.Critical("AdvSyncTargetInfo$ApplyTo got Invalid FakeType");
                         return false;
@@ -347,17 +347,17 @@ namespace CoreSystems
                         ? storage.DummyTargets.PaintedTarget
                         : storage.DummyTargets.ManualTarget;
 
-                    fakeTarget.EntityId = FakeEntityId;
-                    fakeTarget.LocalPosition = FakeLocalPos;
-                    fakeTarget.FakeInfo.WorldPosition = FakeWorldPos;
-                    fakeTarget.FakeInfo.LinearVelocity = LinearVelocity;
-                    fakeTarget.FakeInfo.Acceleration = Acceleration;
+                    fakeTarget.EntityId = FakeEntityId ?? 0;
+                    fakeTarget.LocalPosition = FakeLocalPos ?? Vector3.Zero;
+                    fakeTarget.FakeInfo.WorldPosition = FakeWorldPos ?? Vector3D.Zero;
+                    fakeTarget.FakeInfo.LinearVelocity = LinearVelocity ?? Vector3.Zero;
+                    fakeTarget.FakeInfo.Acceleration = Acceleration ?? Vector3.Zero;
 
                     storage.ManualMode = FakeType == AdvSyncFakeType.Invalid;
                     
                     if (FakeEntityId != 0)
                     {
-                        MyEntities.TryGetEntityById(FakeEntityId, out fakeTarget.TmpEntity);
+                        MyEntities.TryGetEntityById(FakeEntityId ?? 0, out fakeTarget.TmpEntity);
 
                         if (fakeTarget.TmpEntity == null)
                         {

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponData.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponData.cs
@@ -138,7 +138,8 @@ namespace CoreSystems.Platform
                 foreach (var str in Repo.Values.Set.Overrides.UserProjectileTags)
                 {
                     uint val;
-                    if (Session.I.InternalTagToInt.TryGetValue(str, out val))
+                    if (Session.I.InternalTagToInt.TryGetValue(str, out val)
+                        && Comp.PrimaryWeapon.System.WConst.ValidUserProjectileTags.Contains(val))
                     {
                         Repo.Values.Set.Overrides.UserProjectileTagsInternal.Add(val);
                     }

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -953,9 +953,18 @@ namespace CoreSystems.Projectiles
 
                     if ((approach.ModelRotate || aInfo.ModelRotateAge > 0) && approach.ModelMaximumAngleToRotate <= 0)
                     {
+                        if (!approach.AlternateModelForwardUp)
+                        {
+                            aInfo.ModelFwdDir = Vector3D.Normalize(aInfo.TargetPos - Position);
+                        }
+
                         if ((targetLock || approach.AlternateModelForwardUp) && approach.ModelRotateTime > aInfo.ModelRotateAge)
                         {
                             aInfo.ModelRotateMaxAge = approach.ModelRotateTime;
+                            if (aInfo.ModelRotateAge == 0)
+                            {
+                                aInfo.ModelUpDirStart = Info.AvShot.PrimeMatrix == MatrixD.Identity ? Info.OriginUp : Info.AvShot.PrimeMatrix.Up;
+                            }
                             ++aInfo.ModelRotateAge;
                         }
                         else if (aInfo.ModelRotateAge > 0 && (!approach.ModelRotate || (approach.AlternateModelForwardUp ? MyUtils.IsZero(aInfo.ModelFwdDir) : !targetLock)) && --aInfo.ModelRotateAge == 0)

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -1,10 +1,9 @@
-using System;
-using System.Collections.Generic;
 using CoreSystems.Support;
 using Jakaria.API;
 using Sandbox.Game.Entities;
-using Sandbox.ModAPI;
 using Sandbox.ModAPI.Ingame;
+using System;
+using System.Collections.Generic;
 using VRage.Game;
 using VRage.Game.Components;
 using VRage.Game.Entity;
@@ -532,6 +531,8 @@ namespace CoreSystems.Projectiles
             var ai = Info.Ai;
             var session = Session.I;
             var speedCapMulti = 1d;
+            var totalAccelSq = aConst.MaxAccelerationSqr;
+            var deAccelMulti = 1d;
 
             if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.RelativeAge >= aConst.FragStartTime && Info.RelativeAge - Info.LastFragTime > aConst.FragInterval && Info.Frags < aConst.MaxFrags && State <= ProjectileState.Detonate)
             {
@@ -686,9 +687,10 @@ namespace CoreSystems.Projectiles
                 var accelMpsMulti = speedLimitPerTick;
                 bool disableAvoidance = false;
                 bool zeroEffortNav = aConst.ZeroEffortNav;
+                
                 if (aConst.HasApproaches && (s.ApproachInfo.Active || s.RequestedStage == -1))
                 {
-                    ProcessApproach(ref accelMpsMulti, ref speedCapMulti, ref disableAvoidance, ref zeroEffortNav, TargetPosition, s.LastActivatedStage, targetLock);
+                    ProcessApproach(ref accelMpsMulti, ref speedCapMulti, ref disableAvoidance, ref zeroEffortNav, TargetPosition, s.LastActivatedStage, targetLock, ref totalAccelSq, ref deAccelMulti);
                     s.ApproachInfo.Active = s.RequestedStage < aConst.ApproachesCount && s.RequestedStage >= 0;
                 }
 
@@ -696,7 +698,7 @@ namespace CoreSystems.Projectiles
                 Vector3D commandedAccel;
                 Vector3D missileToTargetNorm = Vector3D.Zero;
                 var fastEnoughToTurn = VelocityLengthSqr >= aConst.MinTurnSpeedSqr;
-                if (!aConst.NoSteering && fastEnoughToTurn)
+                if (!aConst.NoSteering && fastEnoughToTurn && Info.TotalAcceleration <= totalAccelSq)
                 {
                     Vector3D targetAcceleration = Vector3D.Zero;
                     if (s.LastVelocity.HasValue)
@@ -842,7 +844,7 @@ namespace CoreSystems.Projectiles
             var speedCap = speedCapMulti * MaxSpeed;
             if (aConst.AmmoUseDrag)
             {
-                speedCap -= Info.Age * aConst.DragPerTick;
+                speedCap -= Info.Age * aConst.DragPerTick * deAccelMulti;
                 if (speedCap < aConst.DragMinSpeed)
                     speedCap = aConst.DragMinSpeed;
                 else if (speedCap < 0)
@@ -853,11 +855,11 @@ namespace CoreSystems.Projectiles
                 proposedVel = Direction * speedCap;
             }
             else
-                Info.TotalAcceleration += (proposedVel - PrevVelocity1);
+                Info.TotalAcceleration += (proposedVel - PrevVelocity1).LengthSquared();
 
             PrevVelocity0 = PrevVelocity1;
             PrevVelocity1 = Velocity;
-            if (Info.TotalAcceleration.LengthSquared() > aConst.MaxAccelerationSqr)
+            if (Info.TotalAcceleration > totalAccelSq)
                 proposedVel = Velocity;
 
             Velocity = proposedVel;
@@ -908,7 +910,7 @@ namespace CoreSystems.Projectiles
             return true;
         }
 
-        private void ProcessApproach(ref double accelMpsMulti, ref double speedCapMulti, ref bool disableAvoidance, ref bool zeroEffortNav, Vector3D targetPos, int lastActiveStage, bool targetLock)
+        private void ProcessApproach(ref double accelMpsMulti, ref double speedCapMulti, ref bool disableAvoidance, ref bool zeroEffortNav, Vector3D targetPos, int lastActiveStage, bool targetLock, ref double totalAccelSq, ref double deAccelMulti)
         {
             var s = Session.I;
             var aConst = Info.AmmoDef.Const;
@@ -1268,6 +1270,8 @@ namespace CoreSystems.Projectiles
                 {
                     accelMpsMulti = aConst.AccelInMetersPerSec * approach.AccelMulti;
                     speedCapMulti = approach.SpeedCapMulti;
+                    totalAccelSq *= approach.TotalAccelMultiSq;
+                    deAccelMulti = approach.DeAccelMulti;
 
                     var fwdDestDir = approach.Forward == FwdRelativeTo.ForwardElevationDirection;
                     var upDestDir = approach.Up == UpRelativeTo.UpElevationDirection;

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -3358,7 +3358,7 @@ namespace CoreSystems.Projectiles
             }
 
             var fireOnTarget = timedSpawn && aConst.HasFragProximity && aConst.FragPointAtTarget;
-            var pos = !Vector3D.IsZero(Info.ProHit.LastHit) && !timedSpawn ? Info.ProHit.LastHit : Position;
+            var pos = timedSpawn || Vector3D.IsZero(Info.ProHit.LastHit) ? Position : Info.ProHit.LastHit;
 
             Vector3D newOrigin;
             if (aConst.HasFragmentOffset)

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -1486,6 +1486,8 @@ namespace CoreSystems.Projectiles
             switch (con)
             {
                 case Conditions.Spawn:
+                    condition = true;
+                    break;
                 case Conditions.Ignore:
                     condition = conditionAnd; // if and, return true so it doesn't block real condition, if or return false so it doesn't false positive
                     break;

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -943,30 +943,26 @@ namespace CoreSystems.Projectiles
                 if (approach.SwapNavigationType)
                     zeroEffortNav = !zeroEffortNav;
 
-                if (EnableAv && (approach.ModelRotate || aInfo.ModelRotateAge > 0))
+                if (EnableAv)
                 {
-                    if (approach.AlternateModelForwardUp)
+                    if (approach.AlternateModelForwardUp && approach.ModelRotate) // don't update if no longer rotating so it rotates back properly
                     {
                         aInfo.ModelFwdDir = GetModelRotateDirection(aConst, aInfo, approach, approach.ModelFwds, targetLock, false);
                         aInfo.ModelUpDir = GetModelRotateDirection(aConst, aInfo, approach, approach.ModelUp, targetLock, true);
-
                     }
 
-                    if (stageChange || (approach.ResetModelRotTimeOnTargetReset && Info.Storage.NewTarget))
+                    if ((approach.ModelRotate || aInfo.ModelRotateAge > 0) && approach.ModelMaximumAngleToRotate <= 0)
                     {
-                        aInfo.ModelFwdDirStart = Info.AvShot.PrimeMatrix == MatrixD.Identity ? Direction : Info.AvShot.PrimeMatrix.Forward;
-                        aInfo.ModelUpDirStart = Info.AvShot.PrimeMatrix == MatrixD.Identity ? Info.OriginUp : Info.AvShot.PrimeMatrix.Up;
-                        aInfo.ModelRotateAge = 0;
-                        Info.Storage.NewTarget = false;
+                        if ((targetLock || approach.AlternateModelForwardUp) && approach.ModelRotateTime > aInfo.ModelRotateAge)
+                        {
+                            aInfo.ModelRotateMaxAge = approach.ModelRotateTime;
+                            ++aInfo.ModelRotateAge;
+                        }
+                        else if (aInfo.ModelRotateAge > 0 && (!approach.ModelRotate || (approach.AlternateModelForwardUp ? MyUtils.IsZero(aInfo.ModelFwdDir) : !targetLock)) && --aInfo.ModelRotateAge == 0)
+                            aInfo.ModelRotateMaxAge = 0;
                     }
 
-                    if ((targetLock || approach.AlternateModelForwardUp) && approach.ModelRotateTime > aInfo.ModelRotateAge)
-                    {
-                        aInfo.ModelRotateMaxAge = approach.ModelRotateTime;
-                        ++aInfo.ModelRotateAge;
-                    }
-                    else if (aInfo.ModelRotateAge > 0 && ((!targetLock && !(approach.AlternateModelForwardUp && aInfo.ModelFwdDir != Vector3.Zero)) || !approach.ModelRotate) && --aInfo.ModelRotateAge == 0)
-                        aInfo.ModelRotateMaxAge = 0;
+                    aInfo.ModelMaxRotateSpeed = approach.ModelMaximumAngleToRotate;
                 }
                 #endregion
 
@@ -2876,12 +2872,6 @@ namespace CoreSystems.Projectiles
                 Info.LastTarget = Info.Target.TargetObject;
                 Info.LastTopTargetId = Info.Target.TopEntityId;
             }
-
-            if (targetChanged && storage != null && storage.RequestedStage >= 0 && (aConst?.Approaches?.Length ?? int.MaxValue) < storage.RequestedStage && 
-                (aConst.Approaches[storage.RequestedStage]?.ResetModelRotTimeOnTargetReset ?? false))
-            {
-                Info.Storage.NewTarget = true;
-            }
             
             if (session.AdvSyncServer && aConst.FullSync && Info.AdvSyncId != 0 && targetChanged)
             {
@@ -3368,7 +3358,7 @@ namespace CoreSystems.Projectiles
             }
 
             var fireOnTarget = timedSpawn && aConst.HasFragProximity && aConst.FragPointAtTarget;
-            var pos = !Vector3D.IsZero(Info.ProHit.LastHit) ? Info.ProHit.LastHit : Position;
+            var pos = !Vector3D.IsZero(Info.ProHit.LastHit) && !timedSpawn ? Info.ProHit.LastHit : Position;
 
             Vector3D newOrigin;
             if (aConst.HasFragmentOffset)

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -1465,6 +1465,8 @@ namespace CoreSystems.Projectiles
                     break;
             }
 
+            if (!MyUtils.IsValid(vec))
+                return Vector3D.Zero;
             return vec;
         }
 

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -311,7 +311,7 @@ namespace CoreSystems.Projectiles
             if (EnableAv)
             {
                 Info.AvShot = session.Av.AvShotPool.Count > 0 ? session.Av.AvShotPool.Pop() : new AvShot(session);
-                Info.AvShot.Init(Info, (aConst.DeltaVelocityPerTick * Session.I.DeltaTimeRatio), MaxSpeed, ref Direction);
+                Info.AvShot.Init(this, Info, (aConst.DeltaVelocityPerTick * Session.I.DeltaTimeRatio), MaxSpeed, ref Direction);
                 Info.AvShot.SetupSounds(distanceFromCameraSqr); //Pool initted sounds per Projectile type... this is expensive
                 if (aConst.HitParticle || aConst.EndOfLifeAoe && !ammoDef.AreaOfDamage.EndOfLife.NoVisuals)
                 {
@@ -533,7 +533,7 @@ namespace CoreSystems.Projectiles
             var session = Session.I;
             var speedCapMulti = 1d;
 
-            if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.RelativeAge >= aConst.FragStartTime && Info.RelativeAge - Info.LastFragTime > aConst.FragInterval && Info.Frags < aConst.MaxFrags)
+            if (aConst.TimedFragments && Info.SpawnDepth < aConst.FragMaxChildren && Info.RelativeAge >= aConst.FragStartTime && Info.RelativeAge - Info.LastFragTime > aConst.FragInterval && Info.Frags < aConst.MaxFrags && State <= ProjectileState.Detonate)
             {
                 if (!aConst.HasFragGroup || Info.Frags == 0 || Info.Frags % aConst.FragGroupSize != 0 || Info.RelativeAge - Info.LastFragTime >= aConst.FragGroupDelay)
                     TimedSpawns(aConst);
@@ -938,23 +938,34 @@ namespace CoreSystems.Projectiles
 
                 var approach = aConst.Approaches[storage.RequestedStage];
 
-                // unneeded branch
-                //if (approach.StartCon1 == approach.StartCon2 || approach.EndCon1 == approach.EndCon2)
-                //    return; // bad modder, failed to read coreparts comment, fail silently so they drive themselves nuts
-
                 disableAvoidance = approach.DisableAvoidance;
 
                 if (approach.SwapNavigationType)
                     zeroEffortNav = !zeroEffortNav;
 
-                if (approach.ModelRotateTime > 0 || aInfo.ModelRotateAge > 0)
+                if (EnableAv && (approach.ModelRotate || aInfo.ModelRotateAge > 0))
                 {
-                    if (targetLock && approach.ModelRotateTime > aInfo.ModelRotateAge)
+                    if (approach.AlternateModelForwardUp)
+                    {
+                        aInfo.ModelFwdDir = GetModelRotateDirection(aConst, aInfo, approach, approach.ModelFwds, targetLock, false);
+                        aInfo.ModelUpDir = GetModelRotateDirection(aConst, aInfo, approach, approach.ModelUp, targetLock, true);
+
+                    }
+
+                    if (stageChange || (approach.ResetModelRotTimeOnTargetReset && Info.Storage.NewTarget))
+                    {
+                        aInfo.ModelFwdDirStart = Info.AvShot.PrimeMatrix == MatrixD.Identity ? Direction : Info.AvShot.PrimeMatrix.Forward;
+                        aInfo.ModelUpDirStart = Info.AvShot.PrimeMatrix == MatrixD.Identity ? Info.OriginUp : Info.AvShot.PrimeMatrix.Up;
+                        aInfo.ModelRotateAge = 0;
+                        Info.Storage.NewTarget = false;
+                    }
+
+                    if ((targetLock || approach.AlternateModelForwardUp) && approach.ModelRotateTime > aInfo.ModelRotateAge)
                     {
                         aInfo.ModelRotateMaxAge = approach.ModelRotateTime;
                         ++aInfo.ModelRotateAge;
                     }
-                    else if (aInfo.ModelRotateAge > 0 && (!targetLock || !approach.ModelRotate) && --aInfo.ModelRotateAge == 0)
+                    else if (aInfo.ModelRotateAge > 0 && ((!targetLock && !(approach.AlternateModelForwardUp && aInfo.ModelFwdDir != Vector3.Zero)) || !approach.ModelRotate) && --aInfo.ModelRotateAge == 0)
                         aInfo.ModelRotateMaxAge = 0;
                 }
                 #endregion
@@ -1376,6 +1387,85 @@ namespace CoreSystems.Projectiles
                 if (s.DebugMod && s.HandlesInput)
                     ApproachDebug(approach, ref positionC, ref positionB, ref elOffset, ref heightOffset, ref targetPos, start1, start2, end1, end2, end3, end4, end5, nextSpawn, timeSinceSpawn, stageChange);
             }
+        }
+
+        private Vector3 GetModelRotateDirection(AmmoConstants aConst, ApproachInfo aInfo, ApproachConstants approach, ModelRelativeTo val, bool hasTarget, bool up)
+        {
+            Vector3 vec;
+            switch (val)
+            {
+                case ModelRelativeTo.ModelRelativeToGravity:
+                    vec = Info.MyPlanet == null ? (up ? Info.OriginUp : Info.OriginFwd) : Vector3D.Normalize(Position - Info.MyPlanet.PositionComp.WorldAABB.Center);
+                    break;
+                case ModelRelativeTo.ModelTargetDirection:
+                    if (hasTarget)
+                        vec = Vector3D.Normalize(aInfo.TargetPos - Position);
+                    else
+                        vec = Vector3.Zero;
+                    break;
+                case ModelRelativeTo.ModelTargetPredictedDirection:
+                    if (hasTarget)
+                    {
+                        var fragAmmoDef = Info.Weapon.System.AmmoTypes[aConst.FragmentId].AmmoDef;
+                        Vector3D pointDir;
+                        Vector3D estimatedTargetPos;
+                        TrajectoryEstimation(fragAmmoDef, ref Position, out pointDir, out estimatedTargetPos, true);
+                        vec = (Vector3)pointDir;
+                    }
+                    else
+                        vec = Vector3.Zero;
+                    break;
+                case ModelRelativeTo.ModelTargetVelocity:
+                    vec = !Vector3D.IsZero(PrevTargetVel) ? Vector3D.Normalize(PrevTargetVel) : Vector3D.Zero;
+                    break;
+                case ModelRelativeTo.ModelStoredStartPosition:
+                case ModelRelativeTo.ModelStoredStartLocalPosition:
+
+                    var storedStartDest = aInfo.Storage[approach.StoredStartId].StoredPosition;
+                    Vector3D destStart;
+                    if (approach.ModelFwds == ModelRelativeTo.ModelStoredStartLocalPosition)
+                        destStart = Vector3D.Transform(storedStartDest, Info.Weapon.Comp.TopEntity.PositionComp.WorldMatrixRef);
+                    else
+                        destStart = storedStartDest != Vector3D.Zero ? storedStartDest : aInfo.TargetPos;
+                    vec = Vector3D.Normalize(destStart - Position);
+                    break;
+                case ModelRelativeTo.ModelStoredEndPosition:
+                case ModelRelativeTo.ModelStoredEndLocalPosition:
+
+                    var storedEndDest = aInfo.Storage[aConst.ApproachesCount + approach.StoredEndId].StoredPosition;
+                    Vector3D destEnd;
+                    if (approach.ModelFwds == ModelRelativeTo.ModelStoredEndLocalPosition)
+                        destEnd = Vector3D.Transform(storedEndDest, Info.Weapon.Comp.TopEntity.PositionComp.WorldMatrixRef);
+                    else
+                        destEnd = storedEndDest != Vector3D.Zero ? storedEndDest : aInfo.TargetPos;
+
+                    vec = Vector3D.Normalize(destEnd - Position);
+                    break;
+
+                case ModelRelativeTo.ModelRelativeToShooterForwards:
+                    vec = Info.Weapon.Comp.CoreEntity.PositionComp.WorldMatrixRef.Forward;
+                    break;
+                case ModelRelativeTo.ModelRelativeToShooterUp:
+                    vec = Info.Weapon.Comp.CoreEntity.PositionComp.WorldMatrixRef.Up;  
+                    break;
+                case ModelRelativeTo.ModelRelativeToShooterDirection:
+                    vec = Vector3D.Normalize(Info.Weapon.Comp.CoreEntity.PositionComp.WorldMatrixRef.Translation - Position);
+                    break;
+                case ModelRelativeTo.ModelOriginForwards:
+                    vec = Info.OriginFwd;
+                    break;
+                case ModelRelativeTo.ModelOriginUp:
+                    vec = Info.OriginUp;
+                    break;
+                case ModelRelativeTo.ModelRelativeToOriginDirection:
+                    vec = Vector3D.Normalize(Info.Origin - Position);
+                    break;
+                default:
+                    vec = Vector3D.Zero;
+                    break;
+            }
+
+            return vec;
         }
 
         // this does NOT need to be inlined and there was a ton of errors with the copied end3 already
@@ -2789,6 +2879,12 @@ namespace CoreSystems.Projectiles
             {
                 Info.LastTarget = Info.Target.TargetObject;
                 Info.LastTopTargetId = Info.Target.TopEntityId;
+            }
+
+            if (targetChanged && storage != null && storage.RequestedStage >= 0 && (aConst?.Approaches?.Length ?? int.MaxValue) < storage.RequestedStage && 
+                (aConst.Approaches[storage.RequestedStage]?.ResetModelRotTimeOnTargetReset ?? false))
+            {
+                Info.Storage.NewTarget = true;
             }
             
             if (session.AdvSyncServer && aConst.FullSync && Info.AdvSyncId != 0 && targetChanged)

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -1456,6 +1456,10 @@ namespace CoreSystems.Projectiles
                 case ModelRelativeTo.ModelRelativeToOriginDirection:
                     vec = Vector3D.Normalize(Info.Origin - Position);
                     break;
+                case ModelRelativeTo.ModelAcceleration:
+                    var accel = (Velocity - PrevVelocity0) * (60 / 2) - (aConst.FeelsGravity ? Gravity : Vector3.Zero);
+                    vec = Vector3D.Normalize(accel);
+                    break;
                 default:
                     vec = Vector3D.Zero;
                     break;

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
@@ -227,6 +227,7 @@ namespace CoreSystems.Support
         internal bool Sleep;
         internal bool PickTarget;
         internal bool ManualMode;
+        internal bool NewTarget; // only used with approaches and model rotation, assume this isn't useful outside of it w/o modifications
         internal int ChaseAge;
         internal int LastOffsetTime;
         internal int SmartSlot;
@@ -254,6 +255,7 @@ namespace CoreSystems.Support
             WasTracking = false;
             PickTarget = false;
             ManualMode = false;
+            NewTarget = false;
 
             Sleep = false;
             
@@ -299,6 +301,10 @@ namespace CoreSystems.Support
         internal Vector3D PositionB;
         internal Vector3D OffsetUpDir;
         internal Vector3D OffsetFwdDir;
+        internal Vector3 ModelUpDir;
+        internal Vector3 ModelUpDirStart;
+        internal Vector3 ModelFwdDir;
+        internal Vector3 ModelFwdDirStart;
         internal double RelativeAgeStart;
         internal double StartDistanceTraveled;
         internal double StartHealth;
@@ -322,6 +328,10 @@ namespace CoreSystems.Support
             PositionB = Vector3D.Zero;
             OffsetUpDir = Vector3D.Zero;
             OffsetFwdDir = Vector3D.Zero;
+            ModelUpDir = Vector3.Zero;
+            ModelUpDirStart = Vector3.Zero;
+            ModelFwdDir = Vector3.Zero;
+            ModelFwdDirStart = Vector3.Zero;
             StartDistanceTraveled = 0;
             RelativeAgeStart = 0;
             RelativeSpawnsStart = 0;

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
@@ -34,7 +34,6 @@ namespace CoreSystems.Support
         internal Vector3D Origin;
         internal Vector3D OriginUp;
         internal Vector3D OriginFwd;
-        internal Vector3D TotalAcceleration;
         internal XorShiftRandomStruct Random;
         internal XorShiftRandomStruct ShieldProc;
         internal int Age = -1;
@@ -61,6 +60,7 @@ namespace CoreSystems.Support
         internal double ShotFade;
         internal double RelativeAge = -1;
         internal double PrevRelativeAge = -1;
+        internal double TotalAcceleration;
         internal long DamageDonePri;
         internal long DamageDoneAoe;
         internal long DamageDoneShld;
@@ -210,7 +210,7 @@ namespace CoreSystems.Support
             OriginFwd = Vector3D.Zero;
             ShooterVel = Vector3D.Zero;
             TriggerMatrix = MatrixD.Identity;
-            TotalAcceleration = Vector3D.Zero;
+            TotalAcceleration = 0;
         }
     }
 

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
@@ -227,7 +227,6 @@ namespace CoreSystems.Support
         internal bool Sleep;
         internal bool PickTarget;
         internal bool ManualMode;
-        internal bool NewTarget; // only used with approaches and model rotation, assume this isn't useful outside of it w/o modifications
         internal int ChaseAge;
         internal int LastOffsetTime;
         internal int SmartSlot;
@@ -255,7 +254,6 @@ namespace CoreSystems.Support
             WasTracking = false;
             PickTarget = false;
             ManualMode = false;
-            NewTarget = false;
 
             Sleep = false;
             
@@ -313,6 +311,7 @@ namespace CoreSystems.Support
         internal double AngleVariance;
         internal int ModelRotateAge;
         internal int ModelRotateMaxAge;
+        internal float ModelMaxRotateSpeed;
         internal bool Active;
         internal void Clean(ProInfo info)
         {
@@ -340,6 +339,7 @@ namespace CoreSystems.Support
             ModelRotateMaxAge = 0;
             ModelRotateAge = 0;
             StartHealth = 0;
+            ModelMaxRotateSpeed = 0;
             Active = false;
             NavTargetBound = new BoundingSphereD(Vector3D.Zero, 0);
             info.AmmoDef.Const.ApproachInfoPool.Push(this);

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
@@ -302,7 +302,6 @@ namespace CoreSystems.Support
         internal Vector3 ModelUpDir;
         internal Vector3 ModelUpDirStart;
         internal Vector3 ModelFwdDir;
-        internal Vector3 ModelFwdDirStart;
         internal double RelativeAgeStart;
         internal double StartDistanceTraveled;
         internal double StartHealth;
@@ -330,7 +329,6 @@ namespace CoreSystems.Support
             ModelUpDir = Vector3.Zero;
             ModelUpDirStart = Vector3.Zero;
             ModelFwdDir = Vector3.Zero;
-            ModelFwdDirStart = Vector3.Zero;
             StartDistanceTraveled = 0;
             RelativeAgeStart = 0;
             RelativeSpawnsStart = 0;

--- a/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
@@ -444,7 +444,6 @@ namespace CoreSystems.Projectiles
                     }
                     
                     MatrixD.CreateWorld(ref p.Position, ref modelDir, ref ModelUp, out info.AvShot.PrimeMatrix);
-                    MyLog.Default.WriteLineAndConsole(info.AvShot.PrimeMatrix.ToString());
                 }
 
                 if (aConst.TriggerModel)

--- a/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
@@ -372,23 +372,23 @@ namespace CoreSystems.Projectiles
                 var aDef = info.AmmoDef;
                 var aConst = aDef.Const;
                 var target = info.Target;
-                var primeModelUpdate = aConst.PrimeModel && p.EnableAv;
-                if (primeModelUpdate || aConst.TriggerModel)
+                if (aConst.PrimeModel && p.EnableAv)
                 {
-                    if (primeModelUpdate) {
-
-                        Vector3D modelDir;
-                        Vector3D ModelUp;
-                        var aInfo = storage.ApproachInfo;
-                        if (aConst.HasApproaches && aInfo.Active && aInfo.ModelRotateMaxAge > 0 && aInfo.ModelRotateAge > 0)
+                    Vector3D modelDir;
+                    Vector3D ModelUp;
+                    var aInfo = storage.ApproachInfo;
+                    if (aConst.HasApproaches && aInfo.Active)
+                    {
+                        if (aInfo.ModelRotateMaxAge > 0 && aInfo.ModelRotateAge >= 0)
                         {
+                            var t = MathHelper.Clamp(aInfo.ModelRotateAge / (float)aInfo.ModelRotateMaxAge, 0, 1);
                             if (MyUtils.IsZero(aInfo.ModelFwdDir))
                             {
-                                modelDir = Vector3.Lerp(p.Direction, aInfo.ModelFwdDirStart, MathHelper.Clamp(aInfo.ModelRotateAge / (float)aInfo.ModelRotateMaxAge, 0, 1));
+                                modelDir = Vector3.Lerp(p.Direction, aInfo.ModelFwdDirStart, t);
                             }
                             else
                             {
-                                modelDir = Vector3.Lerp(aInfo.ModelFwdDirStart, aInfo.ModelFwdDir, MathHelper.Clamp(aInfo.ModelRotateAge / (float)aInfo.ModelRotateMaxAge, 0, 1));
+                                modelDir = Vector3.Lerp(aInfo.ModelFwdDirStart, aInfo.ModelFwdDir, t);
                             }
 
                             if (MyUtils.IsZero(aInfo.ModelUpDir) || aInfo.ModelUpDir == aInfo.ModelFwdDir)
@@ -397,7 +397,38 @@ namespace CoreSystems.Projectiles
                             }
                             else
                             {
-                                ModelUp = Vector3.Lerp(aInfo.ModelUpDirStart, aInfo.ModelUpDir, MathHelper.Clamp(aInfo.ModelRotateAge / (float)aInfo.ModelRotateMaxAge, 0, 1));
+                                ModelUp = Vector3.Lerp(aInfo.ModelUpDirStart, aInfo.ModelUpDir, t);
+                            }
+                        }
+                        else if (aInfo.ModelMaxRotateSpeed > 0)
+                        {
+                            var desiredFor = MyUtils.IsZero(aInfo.ModelFwdDir) ? (Vector3)p.Direction : aInfo.ModelFwdDir;
+                            var desiredUp = MyUtils.IsZero(aInfo.ModelUpDir) || aInfo.ModelUpDir == aInfo.ModelFwdDir ? (Vector3)info.OriginUp : aInfo.ModelUpDir;
+
+                            var currentDir = (Vector3)info.AvShot.PrimeMatrix.Forward;
+                            var currentUp = (Vector3)info.AvShot.PrimeMatrix.Up;
+
+                            var forAngle = MyUtils.GetAngleBetweenVectors(currentDir, desiredFor);
+                            var upAngle = MyUtils.GetAngleBetweenVectors(desiredUp, currentUp);
+
+                            if (Math.Abs(forAngle) < aInfo.ModelMaxRotateSpeed)
+                            {
+                                modelDir = desiredFor;
+                            }
+                            else
+                            {
+                                MatrixD forMat = Matrix.CreateFromAxisAngle(Vector3.Cross(currentDir, desiredFor).Normalized(), forAngle > 0 ? aInfo.ModelMaxRotateSpeed : -aInfo.ModelMaxRotateSpeed);
+                                Vector3D.Transform(ref currentDir, ref forMat, out modelDir);
+                            }
+
+                            if (Math.Abs(upAngle) < aInfo.ModelMaxRotateSpeed)
+                            {
+                                ModelUp = desiredUp;
+                            }
+                            else
+                            {
+                                MatrixD upMat = Matrix.CreateFromAxisAngle(Vector3.Cross(currentUp, desiredUp).Normalized(), upAngle > 0 ? aInfo.ModelMaxRotateSpeed : -aInfo.ModelMaxRotateSpeed);
+                                Vector3D.Transform(ref currentUp, ref upMat, out ModelUp);
                             }
                         }
                         else
@@ -405,13 +436,19 @@ namespace CoreSystems.Projectiles
                             modelDir = p.Direction;
                             ModelUp = info.OriginUp;
                         }
-
-                        MatrixD.CreateWorld(ref p.Position, ref modelDir, ref ModelUp, out info.AvShot.PrimeMatrix);
                     }
-
-                    if (aConst.TriggerModel)
-                        info.TriggerMatrix.Translation = p.Position;
+                    else
+                    {
+                        modelDir = p.Direction;
+                        ModelUp = info.OriginUp;
+                    }
+                    
+                    MatrixD.CreateWorld(ref p.Position, ref modelDir, ref ModelUp, out info.AvShot.PrimeMatrix);
+                    MyLog.Default.WriteLineAndConsole(info.AvShot.PrimeMatrix.ToString());
                 }
+
+                if (aConst.TriggerModel)
+                    info.TriggerMatrix.Translation = p.Position;
 
                 if (aConst.IsBeamWeapon)
                     ++_beamCount;

--- a/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
@@ -593,15 +593,7 @@ namespace CoreSystems.Projectiles
                     else
                     {
                         var forward = (MyUtils.IsZero(p.Velocity, 0.01f) ? p.Direction : p.Velocity).Normalized();
-                        
-                        if (!MyUtils.IsZero(advav.ProjectileMatrix.Left))
-                        {
-                            advav.ProjectileMatrix = MatrixD.CreateWorld(p.Position, forward, advav.ProjectileMatrix.Up);
-                        }
-                        else
-                        {
-                            advav.ProjectileMatrix = MatrixD.CreateWorld(p.Position, forward, p.Info.OriginUp);
-                        }
+                        advav.ProjectileMatrix = MatrixD.CreateWorld(p.Position, forward, advav.ProjectileMatrix.Up);
                     }
                 }
 

--- a/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
@@ -372,7 +372,7 @@ namespace CoreSystems.Projectiles
                 var aDef = info.AmmoDef;
                 var aConst = aDef.Const;
                 var target = info.Target;
-                if (aConst.PrimeModel && p.EnableAv)
+                if ((aConst.PrimeModel && p.EnableAv) || aConst.TriggerModel)
                 {
                     Vector3D modelDir;
                     Vector3D ModelUp;
@@ -384,11 +384,11 @@ namespace CoreSystems.Projectiles
                             var t = MathHelper.Clamp(aInfo.ModelRotateAge / (float)aInfo.ModelRotateMaxAge, 0, 1);
                             if (MyUtils.IsZero(aInfo.ModelFwdDir))
                             {
-                                modelDir = Vector3.Lerp(p.Direction, aInfo.ModelFwdDirStart, t);
+                                modelDir = p.Direction;
                             }
                             else
                             {
-                                modelDir = Vector3.Lerp(aInfo.ModelFwdDirStart, aInfo.ModelFwdDir, t);
+                                modelDir = Vector3.Lerp(p.Direction, aInfo.ModelFwdDir, t);
                             }
 
                             if (MyUtils.IsZero(aInfo.ModelUpDir) || aInfo.ModelUpDir == aInfo.ModelFwdDir)
@@ -444,10 +444,12 @@ namespace CoreSystems.Projectiles
                     }
                     
                     MatrixD.CreateWorld(ref p.Position, ref modelDir, ref ModelUp, out info.AvShot.PrimeMatrix);
+
+                    if (aConst.TriggerModel)
+                        info.TriggerMatrix.Translation = p.Position;
                 }
 
-                if (aConst.TriggerModel)
-                    info.TriggerMatrix.Translation = p.Position;
+                
 
                 if (aConst.IsBeamWeapon)
                     ++_beamCount;

--- a/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
@@ -378,13 +378,35 @@ namespace CoreSystems.Projectiles
                     if (primeModelUpdate) {
 
                         Vector3D modelDir;
+                        Vector3D ModelUp;
                         var aInfo = storage.ApproachInfo;
-                        if (aConst.HasApproaches && aInfo.Active && aInfo.ModelRotateMaxAge > 0 && aInfo.ModelRotateAge > 0 && !MyUtils.IsZero(aInfo.TargetPos)) 
-                            modelDir =  Vector3D.Lerp(p.Direction, Vector3D.Normalize(aInfo.TargetPos - p.Position), aInfo.ModelRotateAge / (double)aInfo.ModelRotateMaxAge);
-                        else
-                            modelDir = p.Direction;
+                        if (aConst.HasApproaches && aInfo.Active && aInfo.ModelRotateMaxAge > 0 && aInfo.ModelRotateAge > 0)
+                        {
+                            if (MyUtils.IsZero(aInfo.ModelFwdDir))
+                            {
+                                modelDir = Vector3.Lerp(p.Direction, aInfo.ModelFwdDirStart, MathHelper.Clamp(aInfo.ModelRotateAge / (float)aInfo.ModelRotateMaxAge, 0, 1));
+                            }
+                            else
+                            {
+                                modelDir = Vector3.Lerp(aInfo.ModelFwdDirStart, aInfo.ModelFwdDir, MathHelper.Clamp(aInfo.ModelRotateAge / (float)aInfo.ModelRotateMaxAge, 0, 1));
+                            }
 
-                        MatrixD.CreateWorld(ref p.Position, ref modelDir, ref info.OriginUp, out info.AvShot.PrimeMatrix);
+                            if (MyUtils.IsZero(aInfo.ModelUpDir) || aInfo.ModelUpDir == aInfo.ModelFwdDir)
+                            {
+                                ModelUp = info.OriginUp;
+                            }
+                            else
+                            {
+                                ModelUp = Vector3.Lerp(aInfo.ModelUpDirStart, aInfo.ModelUpDir, MathHelper.Clamp(aInfo.ModelRotateAge / (float)aInfo.ModelRotateMaxAge, 0, 1));
+                            }
+                        }
+                        else
+                        {
+                            modelDir = p.Direction;
+                            ModelUp = info.OriginUp;
+                        }
+
+                        MatrixD.CreateWorld(ref p.Position, ref modelDir, ref ModelUp, out info.AvShot.PrimeMatrix);
                     }
 
                     if (aConst.TriggerModel)
@@ -517,6 +539,33 @@ namespace CoreSystems.Projectiles
                 }
 
                 if (!p.EnableAv) continue;
+
+                if (aConst.DrawAdvBillboards)
+                {
+                    var advav = info.AvShot.AdvBillboards;
+
+                    advav.PrevPosition = advav.ProjectileMatrix.Translation;
+                    advav.PrevVelocity = advav.Velocity;
+                    advav.Velocity = p.Velocity;
+
+                    if (advav.ModelRotation && advav.Av.HasModel && advav.Av.PrimeEntity != null && advav.Av.PrimeMatrix != MatrixD.Identity)
+                    {
+                        advav.ProjectileMatrix = advav.Av.PrimeMatrix;
+                    }
+                    else
+                    {
+                        var forward = (MyUtils.IsZero(p.Velocity, 0.01f) ? p.Direction : p.Velocity).Normalized();
+                        
+                        if (!MyUtils.IsZero(advav.ProjectileMatrix.Left))
+                        {
+                            advav.ProjectileMatrix = MatrixD.CreateWorld(p.Position, forward, advav.ProjectileMatrix.Up);
+                        }
+                        else
+                        {
+                            advav.ProjectileMatrix = MatrixD.CreateWorld(p.Position, forward, p.Info.OriginUp);
+                        }
+                    }
+                }
 
                 if (p.Intersecting) {
 

--- a/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectiles.cs
@@ -246,9 +246,9 @@ namespace CoreSystems.Projectiles
                                 if (p.VelocityLengthSqr > maxSpeedSqr)
                                     newVel = p.Direction * curMaxSpeed;
                                 else
-                                    info.TotalAcceleration += (newVel - p.PrevVelocity1);
+                                    info.TotalAcceleration += (newVel - p.PrevVelocity1).LengthSquared();
 
-                                if (info.TotalAcceleration.LengthSquared() > aConst.MaxAccelerationSqr)
+                                if (info.TotalAcceleration > aConst.MaxAccelerationSqr)
                                     newVel = p.Velocity;
                             }
 

--- a/Data/Scripts/CoreSystems/Session/SessionInit.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionInit.cs
@@ -33,11 +33,11 @@ namespace CoreSystems
             PlayerId = DedicatedServer ? 0 : Session.Player?.IdentityId ?? -1;
 
             if (IsServer || DedicatedServer)
-                MyAPIGateway.Multiplayer.RegisterMessageHandler(ServerPacketId, ProccessServerPacket);
+                MyAPIGateway.Multiplayer.RegisterSecureMessageHandler(ServerPacketId, ProccessServerPacket);
             else
             {
-                MyAPIGateway.Multiplayer.RegisterMessageHandler(ClientPacketId, ClientReceivedPacket);
-                MyAPIGateway.Multiplayer.RegisterMessageHandler(StringPacketId, StringReceived);
+                MyAPIGateway.Multiplayer.RegisterSecureMessageHandler(ClientPacketId, ClientReceivedPacket);
+                MyAPIGateway.Multiplayer.RegisterSecureMessageHandler(StringPacketId, StringReceived);
 
                 if (DebugSupport.DebugWeaponSync)
                 {

--- a/Data/Scripts/CoreSystems/Session/SessionNetwork.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionNetwork.cs
@@ -8,18 +8,26 @@ using Sandbox.Game.Entities;
 using Sandbox.ModAPI;
 using VRage.Game.Entity;
 using VRageMath;
+using WeaponCore.Data.Scripts.CoreSystems.Support;
 // ReSharper disable ForCanBeConvertedToForeach
 
 namespace CoreSystems
 {
     public partial class Session
     {
-        private void StringReceived(byte[] rawData)
+        private void StringReceived(ushort channelId, byte[] rawData, ulong senderId, bool fromServer)
         {
             try
             {
                 var message = Encoding.UTF8.GetString(rawData, 0, rawData.Length); 
                 if (string.IsNullOrEmpty(message)) return;
+
+                if (!fromServer)
+                {
+                    DebugLog.Warning($"Error: message {message} from sender {senderId} was not server!");
+                    return;
+                }
+
                 var firstChar = message[0];
                 int logId;
                 if (!int.TryParse(firstChar.ToString(), out logId))
@@ -57,7 +65,7 @@ namespace CoreSystems
 
         #region NewClientSwitch
 
-        private void ClientReceivedPacket(byte[] rawData)
+        private void ClientReceivedPacket(ushort channelId, byte[] rawData, ulong senderId, bool fromServer)
         {
             try
             {
@@ -67,6 +75,8 @@ namespace CoreSystems
                     Log.Line("ClientReceivedPacket null packet");
                     return;
                 }
+
+                packet.SenderId = senderId;
 
                 if (packet.PType == PacketType.PingPong)
                 {
@@ -313,10 +323,12 @@ namespace CoreSystems
             PacketsToServer.Clear();
         }
 
-        private void ProccessServerPacket(byte[] rawData)
+        private void ProccessServerPacket(ushort channelId, byte[] rawData, ulong senderId, bool fromServer)
         {
             var packet = MyAPIGateway.Utilities.SerializeFromBinary<Packet>(rawData);
             if (packet == null) return;
+
+            packet.SenderId = senderId;
 
             if (packet.PType == PacketType.PingPong)
             {
@@ -451,8 +463,6 @@ namespace CoreSystems
                         {
                             Packet = new ShootingChangedPacket
                             {
-                                EntityId = 0,
-                                SenderId = MyAPIGateway.Multiplayer.MyId,
                                 PType = PacketType.ShootingChanged,
                                 Value = Settings.Enforcement.ProhibitShooting,
                             },

--- a/Data/Scripts/CoreSystems/Session/SessionRun.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionRun.cs
@@ -418,11 +418,11 @@ namespace CoreSystems
                 ITask.Wait();
 
             if (IsServer || DedicatedServer)
-                MyAPIGateway.Multiplayer.UnregisterMessageHandler(ServerPacketId, ProccessServerPacket);
+                MyAPIGateway.Multiplayer.UnregisterSecureMessageHandler(ServerPacketId, ProccessServerPacket);
             else
             {
-                MyAPIGateway.Multiplayer.UnregisterMessageHandler(ClientPacketId, ClientReceivedPacket);
-                MyAPIGateway.Multiplayer.UnregisterMessageHandler(StringPacketId, StringReceived);
+                MyAPIGateway.Multiplayer.UnregisterSecureMessageHandler(ClientPacketId, ClientReceivedPacket);
+                MyAPIGateway.Multiplayer.UnregisterSecureMessageHandler(StringPacketId, StringReceived);
 
                 if (DebugSupport.DebugWeaponSync)
                 {

--- a/Data/Scripts/CoreSystems/Session/SessionRun.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionRun.cs
@@ -9,6 +9,7 @@ using VRage.Game;
 using VRage.Game.Components;
 using VRage.Game.Entity;
 using VRage.Utils;
+using VRageMath;
 using WeaponCore.Data.Scripts.CoreSystems.Support;
 using static Sandbox.Definitions.MyDefinitionManager;
 
@@ -349,6 +350,7 @@ namespace CoreSystems
 
         public override void LoadData()
         {
+            MyMath.InitializeFastSin();
             AllDefinitions = Static.GetAllDefinitions();
             foreach (var t in AllDefinitions)
             {


### PR DESCRIPTION
will put wiki examples once PR is live
# SERVERS WILL NEED TO UPDATE OR NEW CLIENTS WILL CRASH!
(recommend warning server owners & waiting a day to push)

## Bugfixes
- Fixed TimedSpawns sometimes spawning projectiles in incorrect places if LastHit was set
- Fixed clients being able to spoof who they were (switched to `RegisterSecureMessageHandler`)
- Reduced network load slightly
- Fixed https://github.com/Ash-LikeSnow/WeaponCore/issues/169

## New Graphics System
Much more in depth and configurable system which allows for multiple lines, trails, and even individual tris/quads to be drawn in any orientation relative to the projectile. Performance wise this has slightly more overhead than the current system for a line/a trail, but allows for simplistic distance-based LODs to be setup along with cutting trail billboard counts down using `DelayBetweenSpawns`.

This system can be used with the previous `LineDef` without issue, and you may want to use both in certain scenarios as the new system lacks width/color random variance currently.
(the two systems are completely separate implentation-wise)

Each line is defined via two points relative to the projectile. Each point can be randomly offset, and there are various settings relating to how the line looks/fades, when it renders, and how long it sticks around.

Each trail is defined by one point relative to the projectile, which can be randomly offset. There are various settings relating to how the trail looks/fades, when it renders, and how long the trail is. Trail sections are connected to each other automatically, and do not support any velocity inheritance.
I will personally recommend using these over the old trail definition for lag purposes because `DelayBetweenSpawns` exists.

Each billboard is defined by four points relative to the projectile, and some render settings. Billboards only support being rendered each tick.

https://github.com/user-attachments/assets/75f18cbd-42ab-4bb5-a06e-b093d02e5f6f

A battle like this, with very long (120 tick trail drones/88 tick trail missiles) trails and ~100 drones & many missiles only peaks at ~3k billboards up close, and only ~1k far away due to setting `DelayBetweenSpawns` to 3 only rendered up close, and a separate trail w/ a higher `DelayBetweenSpawns` value only rendered far away. Something like this would previously take like 15k billboards with the old system at the same trail lengths.

In `AmmoDef.GraphicDef`
- Added struct `AdvBillboardsDef`
  - Added `struct Line`
    - `Vector3 P0` - start of the line
    - `float P0RandomOffset` - If greater than zero,  applies random offset to the start position in any direction up to this amount
    - `Vector3 P1` - end of the line
    - `float P1RandomOffset` - If greater than zero,  applies random offset to the end position in any direction up to this amount
    - `Vector4 Color` - color of the line
    - `LineDef.FactionColor FactionColor` - If not `DontUse`, uses the owning faction's Foreground/Background color * 100 componentwise multiplied with `Color` instead of the `Color` defined here
    - `BlendTypeEnum BlendType` - Render options for the given line
    - `string[] Materials` - Material texture of the given line. Progresses from top to bottom every time a new line is generated. Atm there aren't options to modify order, which can simply be done via modifying texture order.
    - `float Width` - Width of the line in arbitrary keen™ units
    - `uint TimeRendered` - In Ticks. 1 = 1 line generated per projectile, 33 is 33 lines drawn per projectile per line. Keep this number low. If this is zero it defaults to 1
    - `uint DelayBetweenSpawns` - Number of ticks between a new line being drawn. 0 means every tick, 1 means every other, etc.
    - `uint DelayBetweenSpawnsOffset` - If nonzero, will offset the DelayBetweenSpawns counter by this amount (internally (Lifetime + DelayBetweenSpawnsOffset) % (DelayBetweenSpawns + 1) = 0 means it spawns)
    - `bool WidthFade` - If true, will lerp Width to 0 as time approaches TimeRendered. Does nothing for TimeRendered = 1
    - `bool ColorFade` - If true, will lerp Color to 0 as time approaches TimeRendered. Does nothing for TimeRendered = 1
    - `float VelocityInheritence` - If not zero, the line will inherit that velocity multiplied by this amount. Negative values are acceptable.
    - `bool AlwaysDraw` - If true, prevents this tracer from being culled. Only use if you have a reason too (very long individual lines)! Position used to test is midpoint of each segment
    - `float RotateSpeed` - If non zero, rotates the definition's positions around the Z axis (forward) counter clock wise by this amount in degrees per second. Negative values are will have it rotate clockwise.
    - `float MinViewDistance` - If greater than zero, then the current line will not be drawn, if the distance between the current camera position and the PROJECTILE position is less than this
    - `float MaxViewDistance` - If greater than zero, then the  current line will not be drawn, if the distance between the current camera position and the PROJECTILE position is greater than this
    - `bool OnlyDrawIfAccelerationAligned` - If true, then the line will only be drawn/scheduled if the projectile's acceleration dotted with the line direction is above the below value (P1 - P0)
    - `float AccelerationDotReq` - Only used if above is true. This will define the required dot product value. Note that neither acceleration or the line length is normalized beforehand!
    - `bool LengthAffectedByAccelAlignment` - If true, then P1 will be scaled down to P0 based off of the absolute value of the acceleration dot product. Distance from P0-P1 will be the maximum length drawn, and for the dot product the line direction will be normalized for the dot product as well. This will also scale width accordingly.
    - `bool AccelAccountForGrav` - If true, then the acceleration vector will be as if the projectile was also countering gravity.
    - `float AccelerationSizeMultiplier` - This multiplies acceleration length accordingly. This value MUST be nonzero
  - Added `struct Trail`
    - `Vector3 P0` - start of the trail
    - `float P0RandomOffset` - If greater than zero,  applies random offset to the start position in any direction up to this amount
    - `Vector4 Color` - color of the trail
    - `LineDef.FactionColor FactionColor` - If not `DontUse`, uses the owning faction's Foreground/Background color * 100 componentwise multiplied with `Color` instead of the `Color` defined here
    - `BlendTypeEnum BlendType` - Render options for the given line
    - `string[] Materials` - Material texture of the given line. Progresses from top to bottom every time a new line is generated. Atm there aren't options to modify order, which can simply be done via modifying texture order.
    - `float Width` - Width of the line in arbitrary keen™ units
    - `uint TimeRendered` - In Ticks. 1 = 1 line generated per projectile per trail, 33 is 33 lines drawn per projectile per line. Keep this number low. If this is zero it defaults to 1
    - `uint DelayBetweenSpawns` - Number of ticks between a new line being drawn. 0 means every tick, 1 means every other, etc. Use when possible, especially for unguided projectiles with straight trails, as when a new line is not being drawn, the previous trail line will be extended to the new projectile position. For best results, keep DelayBetweenSpawns + 1 a clean multiple of TimeRendered (in this case a value of 1+1=2 divides 10 evenly into 5 lines.
    - `uint DelayBetweenSpawnsOffset` - If nonzero, will offset the DelayBetweenSpawns counter by this amount (internally (Lifetime + DelayBetweenSpawnsOffset) % (DelayBetweenSpawns + 1) = 0 means it spawns)
    - `bool WidthFade` - If true, will lerp Width to 0 as time approaches TimeRendered. Does nothing for TimeRendered = 1
    - `bool ColorFade` - If true, will lerp Color to 0 as time approaches TimeRendered. Does nothing for TimeRendered = 1
    - `bool AlwaysDraw` - If true, prevents all lines this trail generates from being culled. Only use if you have a reason too (very long individual lines)! Position used to test is midpoint of each segment. If you're using this because `DelayBetweenSpawns` is large, reduce `DelayBetweenSpawns` over setting this to true.
    - `float RotateSpeed` - If non zero, rotates the definition's positions around the Z axis (forward) counter clock wise by this amount in degrees per second. Negative values are will have it rotate clockwise.
    - `float MinViewDistance` - If greater than zero, then the current trail line will not be drawn & saved, if the distance between the current camera position and the PROJECTILE position is less than this
    - `float MaxViewDistance` - If greater than zero, then the  current trail line will not be drawn & saved, if the distance between the current camera position and the PROJECTILE position is greater than this
  - Added `struct Billboard`
    - `Vector3 P0` - P0 of the quad/tri
    - `Vector3 P1` - P1 of the quad/tri
    - `Vector3 P2` - P2 of the quad/tri
    - `Vector3 P3` - P3 of the quad. If you want a triangle, set P2 equal in value to P3. This enable an optimization.
    - `Vector4 Color` - color of the billboard
    - `LineDef.FactionColor FactionColor` - If not `DontUse`, uses the owning faction's Foreground/Background color * 100 componentwise multiplied with `Color` instead of the `Color` defined here
    - `BlendTypeEnum BlendType` - Render options for the given billboard
    - `string[] Materials` - Material texture of the given billboard. Progresses from top to bottom every tick. Atm there aren't options to modify order, which can simply be done via modifying texture order.
     - `float RotateSpeed` - If non zero, rotates the definition's positions around the Z axis (forward) counter clock wise by this amount in degrees per second. Negative values are will have it rotate clockwise.
    - `float MinViewDistance` - If greater than zero, then the billboard will not be drawn if the distance between the current camera position and the PROJECTILE position is less than this
    - `float MaxViewDistance` - If greater than zero, then the billboard will not be drawn if the distance between the current camera position and the PROJECTILE position is greater than this
    - `uint DelayBetweenSpawns` - Number of ticks between a each billboard being drawn. 0 means every tick, 1 means every other, etc.
    - `uint DelayBetweenSpawnsOffset` - If nonzero, will offset the DelayBetweenSpawns counter by this amount (internally (Lifetime + DelayBetweenSpawnsOffset) % (DelayBetweenSpawns + 1) = 0 means it spawns)
  - `bool Enable`, which does what you expect (if true enables this whole system)
  - `bool UseModelRotation` - which has the following definitions use the visual model's orientation for them, rather than projectile velocity/origin up
  - `Line[] AdvLines` - which is a list of lines the projectile should render
  - `Trail[] AdvTrails` - which is a list of trails the projectile should render
  - `Billboard[] Billboards` - which is a list of billboards the projectile should render
- Added `AdvBillboardsDef AdvancedLines`
  
  ## New Visual Approach Options
A few more settings for the visual model's rotation. Useful if you want a model to orient towards something that isn't just the target, or if model up matters. For example, this could be used in drones in order to aim at the target during combat, have their up direction return up.

In `AmmoDef.TrajectoryDef.ApproachDef`
- Added `bool AlternateModelForwardUp` -if true, enables using `ModelForwards` and `ModelUp` instead of using direction to target and origin up.
- Added `enum ModelRelativeTo` - defines the direction used for an alternate model forwards and up
>`ModelNone` - Don't do anything. If used for forwards, has the model not rotate
>`ModelRelativeToGravity` - Use the projectile's closest planet's gravity
>`ModelTargetDirection` - Use the direction from the projectile to the target. If this is used for forwards its the same as if AlternateModelForwardUp = false
>`ModelTargetPredictedDirection` - Use the direction from the projectile to where the target would be if you were trying to hit it with this projectile's defined fragment (if any - if none same as above)
>`ModelTargetVelocity` - Use the projectile's target's velocity
>`ModelStoredStartPosition` - If a start position was saved at StartEvent then use the direction from the stored position to the launcher for it. This position is absolute and will not update if the launcher's position changes.
>`ModelStoredEndPosition` - If a end position was saved at EndEvent then use the direction from the stored position to the launcher for it. This position is absolute and will not update if the launcher's position changes.
>`ModelStoredStartLocalPosition` - If a local start position was saved at StartEvent then use the direction from the stored position to the launcher for it. This position is relative and will update if the launcher's positon changes.
>`ModelStoredEndLocalPosition` - If a local end position was saved at EndEvent then use the direction from the stored position to the launcher for it. This position is relative and will update if the launcher's positon changes.
>`ModelRelativeToShooterForwards` - Use the forwards direction of the block the projectile originated from. This is updated if the block rotation changes.
>`ModelRelativeToShooterUp` - Use the up direction of the block the projectile originated from. This is updated if the block rotation changes.
>`ModelRelativeToOriginDirection` - Use the direction from the projectile to its origin.
>`ModelOriginForwards` - Use the direction the projectile was facing when it spawned.
>`ModelOriginUp` - Use the up direction the projectile had when it spawned.
>`ModelAcceleration` - Use the projectile's acceleration vector for up. If the projecile is in gravity, it will be subtracted from it - aka if the projectile isn't globally accelerating the "acceleration" value will point up rather than be zero. Useful for "aircraft" up.
- Added `ModelRelativeTo ModelForwards` - defines the desired model forwards direction if `AlternateModelForwardUp = true`.
- Added `ModelRelativeTo ModelUp` - defines the desired model up direction if `AlternateModelForwardUp = true`. This direction will be made perpendicular to forwards direction if not already.
- Added `float ModelMaximumAngleToRotate` - if nonzero, replaces `ModelRotateTime` with a more expensive model rotation limiter to this value in degrees per second, in order to bring ModelForwards/ModelUp (separately) in line with the desired values. This holds even if the desired vectors change rapidly, which `ModelRotateTime` cannot handle as well (visually).